### PR TITLE
fix(justfile): remove invalid [env(...)] attribute on eval recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -244,9 +244,9 @@ pytest *args:
 
 # Run ADK evaluation tests
 [group('testing')]
-[env("PYTHONWARNINGS", "ignore::UserWarning")]
 eval:
-    uv run adk eval voice_assistant tests/evals/*.evalset.json \
+    PYTHONWARNINGS=ignore::UserWarning \
+        uv run adk eval voice_assistant tests/evals/*.evalset.json \
         --config_file_path tests/evals/test_config.json
 
 # ── Quality ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

\`just\` has no \`[env(...)]\` attribute. Its presence at \`justfile:247\` makes \`just\` refuse to parse the whole file with \`error: Unknown attribute \`env\`\`, which breaks **every** recipe — \`adk\`, \`dev\`, \`deploy\`, \`lint\`, \`test\`, etc. — regardless of which one you invoke.

The canonical \`just\` pattern for setting an environment variable on a single recipe is an inline shell prefix on the command line, which is what this PR uses.

## Reproduction (before)

\`\`\`
$ just --list
error: Unknown attribute \`env\`
   ——▶ justfile:247:2
    │
247 │ [env(\"PYTHONWARNINGS\", \"ignore::UserWarning\")]
    │  ^^^
\`\`\`

## Verification (after)

\`\`\`
$ just --list
Available recipes:
    help
    [dev]
    adk
    dev
    repl
    serve
    [ops]
    deploy region=\"europe-west6\"
    ...
    [testing]
    eval
    pytest *args
    test
\`\`\`

All recipes enumerate correctly on \`just\` 1.43.1.

## Testing

- \`just --list\` succeeds
- \`just eval\` parses correctly (not executed — requires Gemini API key)
- \`PYTHONWARNINGS=ignore::UserWarning\` is still applied to the child \`uv run adk eval ...\` process via the inline shell prefix — semantically equivalent to the original intent

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: build-tool / developer-ergonomics fix, no runtime code changed.

---

[![Compound Engineering v2.45.0](https://img.shields.io/badge/Compound_Engineering-v2.45.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)