### PR TITLE
feat: Add ElevenLabs as alternative TTS voice backend (closes #17)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,10 @@ PUBLIC_URL=https://your-ngrok-or-domain.example.com
 # Default language used for the greeting and until the caller's language is detected.
 # Supported: de-CH  fr-CH  it-CH
 DEFAULT_LANGUAGE=de-CH
+
+# ── Voice Backend ────────────────────────────────────────────────────────────
+# "gemini" (default) = Gemini native audio (STT+LLM+TTS in one model)
+# "elevenlabs"       = Gemini for STT+LLM, ElevenLabs for TTS
+VOICE_BACKEND=gemini
+ELEVENLABS_API_KEY=
+ELEVENLABS_MODEL_ID=eleven_turbo_v2_5

--- a/docs/plans/2026-04-15-001-feat-elevenlabs-voice-backend-plan.md
+++ b/docs/plans/2026-04-15-001-feat-elevenlabs-voice-backend-plan.md
@@ -1,0 +1,120 @@
+---
+title: "feat: Add ElevenLabs as alternative voice backend"
+type: feat
+status: active
+date: 2026-04-15
+origin: https://github.com/painless-software/voice-assistant-demo/issues/17
+---
+
+# feat: Add ElevenLabs as alternative voice backend (issue #17)
+
+## Context
+
+The demo currently uses Gemini's native-audio model as a monolithic STT+LLM+TTS pipeline. We want to add ElevenLabs as an alternative TTS backend so operators can compare voice quality, latency, and cost. When ElevenLabs is selected, Gemini still handles STT and LLM (via its Live API in text mode), but TTS is delegated to ElevenLabs' streaming WebSocket API.
+
+## Architecture
+
+**Gemini path (default, unchanged):**
+```
+Caller audio → Gemini Live native-audio (STT+LLM+TTS) → audio → Twilio
+```
+
+**ElevenLabs path (new):**
+```
+Caller audio → Gemini Live text mode (STT+LLM) → text → ElevenLabs TTS → audio → Twilio
+```
+
+Key difference: with ElevenLabs, `response_modalities=["TEXT"]` and we use the standard `gemini-2.5-flash` model (not native-audio) for the Live API. ADK events carry text in `event.content.parts[].text` instead of audio in `event.content.parts[].inline_data`. That text is streamed to ElevenLabs which returns PCM audio chunks.
+
+## Implementation steps
+
+### 1. `voice_assistant/config.py` — add settings and profile fields
+
+- Add to `Settings`: `voice_backend` (str, default `"gemini"`, from `VOICE_BACKEND`), `elevenlabs_api_key` (from `ELEVENLABS_API_KEY`), `elevenlabs_model_id` (default `"eleven_turbo_v2_5"`, from `ELEVENLABS_MODEL_ID`)
+- Add `elevenlabs_voice_id` to each language profile (ElevenLabs voice IDs per language)
+- Extend `validate()`: when `voice_backend == "elevenlabs"`, require `elevenlabs_api_key`
+
+### 2. `voice_assistant/elevenlabs_tts.py` — new file, streaming TTS client
+
+Async WebSocket client wrapping ElevenLabs' text-to-speech streaming API (`wss://api.elevenlabs.io/v1/text-to-speech/{voice_id}/stream-input`). ~80-100 lines.
+
+- `ElevenLabsTTS` class with:
+  - `connect(voice_id, model_id, api_key, output_format)` — opens WebSocket, sends BOS (beginning-of-stream) config
+  - `send_text(text)` — streams a text chunk
+  - `flush()` — sends empty string to signal end of input, triggering final audio generation
+  - `receive_audio()` — async generator yielding raw PCM audio chunks (decoded from base64 in the response JSON)
+  - `interrupt()` — closes the WebSocket to abort generation
+- Uses `websockets` library (already a transitive dep via google-adk, add explicitly to pyproject.toml)
+- Output format: `pcm_24000` (16-bit PCM@24kHz) — matches Gemini's output, so existing `gemini_pcm_to_twilio_mulaw_b64()` works unchanged
+
+### 3. `voice_assistant/agent.py` — conditional live model
+
+When `voice_backend == "elevenlabs"`, the live model should be the standard text model (not native-audio), since we only need STT+LLM from Gemini:
+
+```python
+class _DualModelGemini(Gemini):
+    live_model: str = (
+        GEMINI_MODEL if settings.voice_backend == "elevenlabs" else GEMINI_LIVE_MODEL
+    )
+```
+
+### 4. `voice_assistant/call_handler.py` — branch on backend
+
+**In `handle_media_stream()`:**
+- When `voice_backend == "gemini"`: current RunConfig with `response_modalities=["AUDIO"]` and `speech_config`
+- When `voice_backend == "elevenlabs"`: RunConfig with `response_modalities=["TEXT"]`, no speech_config
+
+**In `_adk_to_twilio()`:**
+- Add an `ElevenLabsTTS` instance (created per call) when backend is elevenlabs
+- New helper `_stream_text_to_tts(event, tts)` — extracts text from `event.content.parts[].text`, calls `tts.send_text()`
+- Spawn a background task `_tts_audio_to_twilio(tts, ws, sid_holder)` that reads from `tts.receive_audio()` and forwards converted mulaw to Twilio
+- Farewell detection: use `event.content.parts[].text` directly (since `output_transcription` may not be available in text mode)
+- On interrupt: call `tts.interrupt()` in addition to sending Twilio `clear`
+- On flush (end of agent turn): call `tts.flush()`
+
+**Barge-in with ElevenLabs:**
+1. Gemini detects caller speech → `event.interrupted = True`
+2. Send Twilio `clear` (same as now)
+3. Call `tts.interrupt()` — closes WebSocket, stops audio generation
+4. Set `interrupt_latched` (same as now) — suppresses stale text events
+5. On next user turn: latch clears, new TTS WebSocket opened for next agent response
+
+### 5. `voice_assistant/audio.py` — no changes
+
+ElevenLabs outputs PCM@24kHz (via `pcm_24000` format), same as Gemini. The existing `gemini_pcm_to_twilio_mulaw_b64()` works as-is.
+
+### 6. `pyproject.toml` — add dependency
+
+Run `uv add websockets` to add the dependency.
+
+### 7. `.env.example` — document new variables
+
+Add a `Voice Backend` section with `VOICE_BACKEND`, `ELEVENLABS_API_KEY`, `ELEVENLABS_MODEL_ID`.
+
+### 8. Tests
+
+- **`tests/unit/test_elevenlabs_tts.py`** (new) — test `send_text`, `flush`, `receive_audio`, `interrupt` with a mock WebSocket
+- **`tests/unit/test_call_handler.py`** — add tests for elevenlabs path: text events streamed to TTS, barge-in calls `tts.interrupt()`, farewell detection from text content
+- **`tests/unit/test_config.py`** — test new settings fields, validation when `voice_backend == "elevenlabs"`
+
+## Files to modify/create
+
+| File | Action |
+|---|---|
+| `voice_assistant/config.py` | Modify — add settings + profile fields |
+| `voice_assistant/elevenlabs_tts.py` | **Create** — streaming TTS client |
+| `voice_assistant/agent.py` | Modify — conditional live model (~2 lines) |
+| `voice_assistant/call_handler.py` | Modify — branch on backend, TTS integration |
+| `voice_assistant/audio.py` | No changes |
+| `pyproject.toml` | Modify via `uv add websockets` |
+| `.env.example` | Modify — document new env vars |
+| `tests/unit/test_elevenlabs_tts.py` | **Create** — TTS client tests |
+| `tests/unit/test_call_handler.py` | Modify — add elevenlabs path tests |
+| `tests/unit/test_config.py` | Modify — test new settings |
+
+## Verification
+
+1. `just pytest` — all existing + new tests pass
+2. `just fmt` — formatting clean
+3. Set `VOICE_BACKEND=gemini` (or unset) — existing behavior unchanged
+4. Manual test with `VOICE_BACKEND=elevenlabs` + `ELEVENLABS_API_KEY` — caller hears ElevenLabs voice

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.13"
 dependencies = [
     "google-adk>=1.28.0",
     "audioop-lts>=0.2.1",   # mulaw <-> pcm conversion (Python 3.13+ compatible)
+    "websockets>=15.0.1",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/unit/test_call_handler.py
+++ b/tests/unit/test_call_handler.py
@@ -806,10 +806,10 @@ async def test_handle_media_stream_one_task_finishes_other_cancelled(
 def _make_mock_tts():
     """Create a mock ElevenLabsTTS with pre-wired async methods."""
     tts = MagicMock()
-    tts._ws = None  # not connected yet
+    tts.is_connected = False
 
     async def _fake_connect(*a, **kw):
-        tts._ws = MagicMock()  # mark as connected
+        tts.is_connected = True
 
     tts.connect = AsyncMock(side_effect=_fake_connect)
     tts.send_text = AsyncMock()

--- a/tests/unit/test_call_handler.py
+++ b/tests/unit/test_call_handler.py
@@ -11,6 +11,7 @@ import pytest
 
 from voice_assistant.call_handler import (
     _adk_to_twilio,
+    _tts_audio_to_twilio,
     _twilio_to_adk,
     _wait_for_goodbye_mark,
     handle_media_stream,
@@ -37,8 +38,13 @@ def _make_event(
     output_text: str | None = None,
     input_text: str | None = None,
     interrupted: bool | None = None,
+    text_content: str | None = None,
 ) -> SimpleNamespace:
-    """Build a fake ADK event with the requested attributes."""
+    """Build a fake ADK event with the requested attributes.
+
+    ``text_content`` adds a text part to ``content.parts`` (ElevenLabs path).
+    ``output_text`` sets ``output_transcription.text`` (Gemini audio path).
+    """
     parts = []
     if audio_data is not None:
         parts.append(
@@ -47,6 +53,8 @@ def _make_event(
                 function_call=None,
             )
         )
+    if text_content is not None:
+        parts.append(SimpleNamespace(text=text_content, inline_data=None))
     content = SimpleNamespace(parts=parts) if parts else SimpleNamespace(parts=[])
 
     output_transcription = None
@@ -189,25 +197,18 @@ async def test_twilio_goodbye_timeout():
     )
 
 
-async def test_twilio_receive_timeout_handled():
+@pytest.mark.parametrize(
+    "exc_factory",
+    [
+        lambda: asyncio.TimeoutError(),
+        lambda: RuntimeError("boom"),
+        lambda: __import__("fastapi").WebSocketDisconnect(),
+    ],
+    ids=["timeout", "generic_error", "websocket_disconnect"],
+)
+async def test_twilio_error_handling(exc_factory):
     ws = AsyncMock()
-    ws.receive_text.side_effect = asyncio.TimeoutError()
-
-    await _twilio_to_adk(ws, MagicMock(), [None], asyncio.Event())
-
-
-async def test_twilio_generic_error_handled():
-    ws = AsyncMock()
-    ws.receive_text.side_effect = RuntimeError("boom")
-
-    await _twilio_to_adk(ws, MagicMock(), [None], asyncio.Event())
-
-
-async def test_twilio_websocket_disconnect_handled():
-    from fastapi import WebSocketDisconnect
-
-    ws = AsyncMock()
-    ws.receive_text.side_effect = WebSocketDisconnect()
+    ws.receive_text.side_effect = exc_factory()
 
     await _twilio_to_adk(ws, MagicMock(), [None], asyncio.Event())
 
@@ -217,7 +218,7 @@ async def test_twilio_websocket_disconnect_handled():
 # ---------------------------------------------------------------------------
 
 
-def _run_adk(events, ws, sid_holder=None, call_end_event=None):
+def _run_adk(events, ws, sid_holder=None, call_end_event=None, tts=None):
     """Helper to call _adk_to_twilio with mocked runner."""
     runner = MagicMock()
     runner.run_live = lambda **kw: _fake_run_live(events, **kw)
@@ -230,6 +231,7 @@ def _run_adk(events, ws, sid_holder=None, call_end_event=None):
         run_config=MagicMock(),
         sid_holder=sid_holder or ["SM-1"],
         call_end_event=call_end_event or asyncio.Event(),
+        tts=tts,
     )
 
 
@@ -375,6 +377,68 @@ async def test_drain_cancel_resets_draining_state(mock_convert):
 
     # call_end_event should NOT be set — drain was cancelled
     assert not call_end_event.is_set()
+
+
+@patch(
+    "voice_assistant.call_handler.gemini_pcm_to_twilio_mulaw_b64",
+    return_value="x",
+)
+async def test_input_transcription_without_text_is_ignored(mock_convert):
+    """An input_transcription with no text attribute does not clear drain."""
+    ws = AsyncMock()
+    call_end_event = asyncio.Event()
+    # Event has input_transcription but text is empty
+    event = SimpleNamespace(
+        content=SimpleNamespace(parts=[]),
+        output_transcription=None,
+        input_transcription=SimpleNamespace(text=""),
+        interrupted=None,
+    )
+    events = [
+        _make_event(output_text="Goodbye!", audio_data=b"\x00"),  # drain ON, has audio
+        event,  # should NOT cancel drain (empty text)
+        _make_event(),  # completes drain (no audio)
+    ]
+
+    await _run_adk(events, ws, call_end_event=call_end_event)
+
+    assert call_end_event.is_set()
+
+
+@patch(
+    "voice_assistant.call_handler.gemini_pcm_to_twilio_mulaw_b64",
+    return_value="x",
+)
+async def test_output_transcription_without_text_is_ignored(mock_convert):
+    """An output_transcription with no text attribute does not trigger drain."""
+    ws = AsyncMock()
+    call_end_event = asyncio.Event()
+    event = SimpleNamespace(
+        content=SimpleNamespace(parts=[]),
+        output_transcription=SimpleNamespace(text=""),
+        input_transcription=None,
+        interrupted=None,
+    )
+    events = [event, _make_event()]
+
+    await _run_adk(events, ws, call_end_event=call_end_event)
+
+    assert not call_end_event.is_set()
+
+
+@patch(
+    "voice_assistant.call_handler.gemini_pcm_to_twilio_mulaw_b64",
+    return_value="x",
+)
+async def test_relay_audio_skips_parts_without_inline_data(mock_convert):
+    """Audio relay skips text-only parts (no inline_data)."""
+    ws = AsyncMock()
+    # Event with a text part (no inline_data) — should be skipped by _relay_audio
+    events = [_make_event(text_content="just text")]
+
+    await _run_adk(events, ws)
+
+    mock_convert.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -602,33 +666,20 @@ async def test_adk_websocket_disconnect_handled():
         await _run_adk(events, ws)
 
 
-async def test_adk_generic_error_handled():
+@pytest.mark.parametrize(
+    "exc_factory",
+    [
+        lambda: RuntimeError("unexpected"),
+        lambda: asyncio.CancelledError(),
+    ],
+    ids=["generic_error", "cancelled"],
+)
+async def test_adk_runner_error_handled(exc_factory):
     ws = AsyncMock()
+    exc = exc_factory()
 
     async def _raising_gen(**kw):
-        raise RuntimeError("unexpected")
-        yield
-
-    runner = MagicMock()
-    runner.run_live = _raising_gen
-
-    await _adk_to_twilio(
-        ws=ws,
-        runner=runner,
-        user_id="u",
-        session_id="s",
-        live_queue=MagicMock(),
-        run_config=MagicMock(),
-        sid_holder=["SM-1"],
-        call_end_event=asyncio.Event(),
-    )
-
-
-async def test_adk_cancelled_error_handled():
-    ws = AsyncMock()
-
-    async def _raising_gen(**kw):
-        raise asyncio.CancelledError
+        raise exc
         yield  # make it an async generator
 
     runner = MagicMock()
@@ -745,3 +796,238 @@ async def test_handle_media_stream_one_task_finishes_other_cancelled(
     await asyncio.wait_for(handle_media_stream(ws), timeout=5.0)
 
     ws.close.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# ElevenLabs voice backend path
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_tts():
+    """Create a mock ElevenLabsTTS with pre-wired async methods."""
+    tts = MagicMock()
+    tts._ws = None  # not connected yet
+
+    async def _fake_connect(*a, **kw):
+        tts._ws = MagicMock()  # mark as connected
+
+    tts.connect = AsyncMock(side_effect=_fake_connect)
+    tts.send_text = AsyncMock()
+    tts.flush = AsyncMock()
+    tts.interrupt = AsyncMock()
+
+    async def _no_audio():
+        return
+        yield  # make it an async generator
+
+    tts.receive_audio = _no_audio
+    return tts
+
+
+@pytest.fixture()
+def _patch_elevenlabs_settings():
+    """Patch settings for ElevenLabs tests."""
+    with patch(f"{_CH}.settings") as mock_settings:
+        mock_settings.language_profile.return_value = {
+            "elevenlabs_voice_id": "voice-1",
+        }
+        mock_settings.elevenlabs_model_id = "model-1"
+        mock_settings.elevenlabs_api_key = "key-1"
+        yield mock_settings
+
+
+@pytest.mark.usefixtures("_patch_elevenlabs_settings")
+async def test_elevenlabs_text_streamed_to_tts():
+    """Text content from ADK events is forwarded to the ElevenLabs TTS client."""
+    tts = _make_mock_tts()
+    ws = AsyncMock()
+    events = [
+        _make_event(text_content="Hello "),
+        _make_event(text_content="world!"),
+    ]
+
+    await _run_adk(events, ws, tts=tts)
+
+    tts.connect.assert_awaited_once()
+    assert tts.send_text.await_count == 2
+    tts.send_text.assert_any_await("Hello ")
+    tts.send_text.assert_any_await("world!")
+
+
+@pytest.mark.usefixtures("_patch_elevenlabs_settings")
+async def test_elevenlabs_farewell_triggers_drain():
+    """Farewell phrase in text content triggers drain and flush."""
+    tts = _make_mock_tts()
+    ws = AsyncMock()
+    call_end_event = asyncio.Event()
+    events = [_make_event(text_content="Auf Wiederhören!")]
+
+    await _run_adk(events, ws, call_end_event=call_end_event, tts=tts)
+
+    assert call_end_event.is_set()
+    tts.flush.assert_awaited_once()
+
+
+@pytest.mark.usefixtures("_patch_elevenlabs_settings")
+async def test_elevenlabs_interrupt_calls_tts_interrupt():
+    """Barge-in with ElevenLabs backend calls tts.interrupt()."""
+    tts = _make_mock_tts()
+    ws = AsyncMock()
+    events = [_make_event(interrupted=True)]
+
+    await _run_adk(events, ws, sid_holder=["SM-1"], tts=tts)
+
+    # Twilio clear was sent
+    sent = [json.loads(c[0][0]) for c in ws.send_text.call_args_list]
+    assert any(m.get("event") == "clear" for m in sent)
+    # TTS was interrupted (at least once — once in handler, once in finally)
+    assert tts.interrupt.await_count >= 1
+
+
+@pytest.mark.usefixtures("_patch_elevenlabs_settings")
+async def test_elevenlabs_stale_text_dropped_while_latched():
+    """Text events arriving while interrupt_latched are not sent to TTS."""
+    tts = _make_mock_tts()
+    ws = AsyncMock()
+    events = [
+        _make_event(interrupted=True),
+        _make_event(text_content="stale response"),  # should be dropped
+    ]
+
+    await _run_adk(events, ws, tts=tts)
+
+    tts.send_text.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("_patch_elevenlabs_settings")
+async def test_elevenlabs_text_resumes_after_new_user_turn():
+    """After interrupt + new user turn, TTS reconnects and text flows again."""
+    tts = _make_mock_tts()
+    ws = AsyncMock()
+    events = [
+        _make_event(interrupted=True),
+        _make_event(input_text="Wait, another question"),
+        _make_event(text_content="New response"),
+    ]
+
+    await _run_adk(events, ws, tts=tts)
+
+    tts.connect.assert_awaited_once()
+    tts.send_text.assert_awaited_once_with("New response")
+
+
+@pytest.mark.usefixtures("_patch_elevenlabs_settings")
+async def test_elevenlabs_no_text_means_no_connect():
+    """If no text events arrive, TTS is never connected."""
+    tts = _make_mock_tts()
+    ws = AsyncMock()
+    events = [_make_event()]  # empty event
+
+    await _run_adk(events, ws, tts=tts)
+
+    tts.connect.assert_not_awaited()
+    tts.send_text.assert_not_awaited()
+
+
+@patch(
+    "voice_assistant.call_handler.gemini_pcm_to_twilio_mulaw_b64",
+    return_value="bXVsYXc=",
+)
+async def test_tts_audio_to_twilio_forwards_audio(mock_convert):
+    """_tts_audio_to_twilio converts PCM from TTS and sends mulaw to Twilio."""
+    tts = _make_mock_tts()
+
+    async def _yield_audio():
+        yield b"\x00\x01\x02"
+        yield b"\x03\x04"
+
+    tts.receive_audio = _yield_audio
+
+    ws = AsyncMock()
+    await _tts_audio_to_twilio(tts, ws, ["SM-1"])
+
+    assert mock_convert.call_count == 2
+    sent = [json.loads(c[0][0]) for c in ws.send_text.call_args_list]
+    media_msgs = [m for m in sent if m.get("event") == "media"]
+    assert len(media_msgs) == 2
+    assert media_msgs[0]["media"]["payload"] == "bXVsYXc="
+    assert media_msgs[0]["streamSid"] == "SM-1"
+    tts_marks = [m for m in sent if m.get("mark", {}).get("name") == "tts-chunk"]
+    assert len(tts_marks) == 2
+
+
+@patch(
+    "voice_assistant.call_handler.gemini_pcm_to_twilio_mulaw_b64",
+    return_value="x",
+)
+async def test_tts_audio_to_twilio_drops_without_sid(mock_convert):
+    """_tts_audio_to_twilio drops audio when no stream SID is available."""
+    tts = _make_mock_tts()
+
+    async def _yield_audio():
+        yield b"\x00"
+
+    tts.receive_audio = _yield_audio
+
+    ws = AsyncMock()
+    with patch("voice_assistant.call_handler.asyncio.sleep", new_callable=AsyncMock):
+        await _tts_audio_to_twilio(tts, ws, [None])
+
+    ws.send_text.assert_not_called()
+
+
+@pytest.mark.usefixtures("_patch_elevenlabs_settings")
+async def test_elevenlabs_interrupt_cancels_tts_receiver():
+    """Barge-in while TTS receiver is active cancels the receiver task."""
+    tts = _make_mock_tts()
+
+    # Make receive_audio hang so the receiver task is still running at interrupt
+    hang_event = asyncio.Event()
+
+    async def _hang_audio():
+        await hang_event.wait()
+        return
+        yield  # async generator
+
+    tts.receive_audio = _hang_audio
+
+    ws = AsyncMock()
+    events = [
+        _make_event(text_content="Hello"),
+        _make_event(interrupted=True),
+    ]
+
+    await _run_adk(events, ws, sid_holder=["SM-1"], tts=tts)
+
+    # The test completes without hanging — receiver was cancelled
+
+
+@patch(f"{_CH}._adk_to_twilio", new_callable=AsyncMock)
+@patch(f"{_CH}._twilio_to_adk", new_callable=AsyncMock)
+@patch(f"{_CH}.LiveRequestQueue")
+@patch(f"{_CH}.InMemoryRunner")
+@patch(f"{_CH}.settings")
+async def test_handle_media_stream_elevenlabs_backend(
+    mock_settings, mock_runner_cls, mock_queue_cls, mock_twilio, mock_adk
+):
+    """handle_media_stream creates ElevenLabsTTS and text RunConfig for elevenlabs."""
+    mock_settings.voice_backend = "elevenlabs"
+    mock_settings.language_profile.return_value = {"voice_name": "Leda"}
+
+    mock_runner = MagicMock()
+    mock_session = MagicMock()
+    mock_session.id = "session-1"
+    mock_runner.session_service.create_session = AsyncMock(return_value=mock_session)
+    mock_runner_cls.return_value = mock_runner
+    mock_queue_cls.return_value = MagicMock()
+
+    ws = AsyncMock()
+
+    await handle_media_stream(ws)
+
+    # _adk_to_twilio should have been called with a TTS instance
+    from voice_assistant.elevenlabs_tts import ElevenLabsTTS
+
+    call_kwargs = mock_adk.call_args[1] if mock_adk.call_args[1] else {}
+    assert "tts" in call_kwargs
+    assert isinstance(call_kwargs["tts"], ElevenLabsTTS)

--- a/tests/unit/test_call_handler.py
+++ b/tests/unit/test_call_handler.py
@@ -16,6 +16,7 @@ from voice_assistant.call_handler import (
     _wait_for_goodbye_mark,
     handle_media_stream,
 )
+from voice_assistant.elevenlabs_tts import ElevenLabsTTS
 
 # Patch paths for call_handler module
 _CH = "voice_assistant.call_handler"
@@ -804,22 +805,25 @@ async def test_handle_media_stream_one_task_finishes_other_cancelled(
 
 
 def _make_mock_tts():
-    """Create a mock ElevenLabsTTS with pre-wired async methods."""
-    tts = MagicMock()
+    """Create a mock ElevenLabsTTS with pre-wired async methods.
+
+    Uses ``spec=ElevenLabsTTS`` so the mock fails loudly if the client
+    interface drifts (new method added, existing method renamed).
+    """
+    tts = AsyncMock(spec=ElevenLabsTTS)
     tts.is_connected = False
 
     async def _fake_connect(*a, **kw):
         tts.is_connected = True
 
-    tts.connect = AsyncMock(side_effect=_fake_connect)
-    tts.send_text = AsyncMock()
-    tts.flush = AsyncMock()
-    tts.interrupt = AsyncMock()
+    tts.connect.side_effect = _fake_connect
 
     async def _no_audio():
         return
         yield  # make it an async generator
 
+    # ``receive_audio`` must be a callable returning an async generator,
+    # not an AsyncMock (which would be a coroutine).
     tts.receive_audio = _no_audio
     return tts
 
@@ -952,8 +956,8 @@ async def test_tts_audio_to_twilio_forwards_audio(mock_convert):
     assert len(media_msgs) == 2
     assert media_msgs[0]["media"]["payload"] == "bXVsYXc="
     assert media_msgs[0]["streamSid"] == "SM-1"
-    tts_marks = [m for m in sent if m.get("mark", {}).get("name") == "tts-chunk"]
-    assert len(tts_marks) == 2
+    # TTS chunks deliberately carry no mark (no consumer for it).
+    assert not any(m.get("event") == "mark" for m in sent)
 
 
 @patch(
@@ -1002,17 +1006,26 @@ async def test_elevenlabs_interrupt_cancels_tts_receiver():
     # The test completes without hanging — receiver was cancelled
 
 
+@patch(f"{_CH}.ElevenLabsTTS")
 @patch(f"{_CH}._adk_to_twilio", new_callable=AsyncMock)
 @patch(f"{_CH}._twilio_to_adk", new_callable=AsyncMock)
 @patch(f"{_CH}.LiveRequestQueue")
 @patch(f"{_CH}.InMemoryRunner")
 @patch(f"{_CH}.settings")
 async def test_handle_media_stream_elevenlabs_backend(
-    mock_settings, mock_runner_cls, mock_queue_cls, mock_twilio, mock_adk
+    mock_settings, mock_runner_cls, mock_queue_cls, mock_twilio, mock_adk, mock_tts_cls
 ):
     """handle_media_stream creates ElevenLabsTTS and text RunConfig for elevenlabs."""
     mock_settings.voice_backend = "elevenlabs"
-    mock_settings.language_profile.return_value = {"voice_name": "Leda"}
+    mock_settings.language_profile.return_value = {
+        "voice_name": "Leda",
+        "elevenlabs_voice_id": "voice-1",
+    }
+    mock_settings.elevenlabs_model_id = "model-1"
+    mock_settings.elevenlabs_api_key = "key-1"
+
+    mock_tts = _make_mock_tts()
+    mock_tts_cls.return_value = mock_tts
 
     mock_runner = MagicMock()
     mock_session = MagicMock()
@@ -1025,9 +1038,10 @@ async def test_handle_media_stream_elevenlabs_backend(
 
     await handle_media_stream(ws)
 
-    # _adk_to_twilio should have been called with a TTS instance
-    from voice_assistant.elevenlabs_tts import ElevenLabsTTS
-
+    # TTS instance passed to _adk_to_twilio is the same one we pre-connected
     call_kwargs = mock_adk.call_args[1] if mock_adk.call_args[1] else {}
-    assert "tts" in call_kwargs
-    assert isinstance(call_kwargs["tts"], ElevenLabsTTS)
+    assert call_kwargs.get("tts") is mock_tts
+    # Handshake happens eagerly in handle_media_stream (not lazily in adk loop)
+    mock_tts.connect.assert_awaited_once_with(
+        voice_id="voice-1", model_id="model-1", api_key="key-1"
+    )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -128,3 +128,37 @@ def test_use_vertex_ai_false_when_api_key_set():
 def test_use_vertex_ai_true_when_only_project():
     s = Settings(google_api_key=None, google_cloud_project="proj")
     assert s.use_vertex_ai() is True
+
+
+# ---------------------------------------------------------------------------
+# ElevenLabs settings
+# ---------------------------------------------------------------------------
+
+
+def test_voice_backend_defaults_to_gemini():
+    s = Settings(google_api_key="key")
+    assert s.voice_backend == "gemini"
+
+
+def test_elevenlabs_requires_api_key():
+    s = Settings(
+        google_api_key="key", voice_backend="elevenlabs", elevenlabs_api_key=""
+    )
+    with pytest.raises(EnvironmentError, match="ELEVENLABS_API_KEY"):
+        s.validate(require_twilio=False)
+
+
+def test_elevenlabs_with_api_key_passes():
+    s = Settings(
+        google_api_key="key",
+        voice_backend="elevenlabs",
+        elevenlabs_api_key="el-key",
+    )
+    s.validate(require_twilio=False)  # should not raise
+
+
+@pytest.mark.parametrize("lang_code", ["de-CH", "de-DE", "fr-CH", "it-CH"])
+def test_language_profile_has_elevenlabs_voice_id(lang_code):
+    profile = LANGUAGE_PROFILES[lang_code]
+    assert "elevenlabs_voice_id" in profile
+    assert len(profile["elevenlabs_voice_id"]) > 0

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -140,6 +140,12 @@ def test_voice_backend_defaults_to_gemini():
     assert s.voice_backend == "gemini"
 
 
+def test_invalid_voice_backend_raises():
+    s = Settings(google_api_key="key", voice_backend="elevenlab")
+    with pytest.raises(EnvironmentError, match="not valid"):
+        s.validate(require_twilio=False)
+
+
 def test_elevenlabs_requires_api_key():
     s = Settings(
         google_api_key="key", voice_backend="elevenlabs", elevenlabs_api_key=""

--- a/tests/unit/test_elevenlabs_tts.py
+++ b/tests/unit/test_elevenlabs_tts.py
@@ -168,6 +168,7 @@ async def test_receive_audio_handles_connection_closed():
 
     received = [c async for c in tts.receive_audio()]
     assert received == []
+    assert not tts.is_connected
 
 
 @patch("voice_assistant.elevenlabs_tts.websockets.connect", new_callable=AsyncMock)

--- a/tests/unit/test_elevenlabs_tts.py
+++ b/tests/unit/test_elevenlabs_tts.py
@@ -1,0 +1,207 @@
+"""Unit tests for ElevenLabs streaming TTS client."""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from voice_assistant.elevenlabs_tts import ElevenLabsTTS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _audio_msg(pcm_data: bytes) -> str:
+    """Build a JSON ElevenLabs audio response."""
+    return json.dumps({"audio": base64.b64encode(pcm_data).decode()})
+
+
+def _final_msg() -> str:
+    return json.dumps({"isFinal": True})
+
+
+# ---------------------------------------------------------------------------
+# connect
+# ---------------------------------------------------------------------------
+
+
+@patch("voice_assistant.elevenlabs_tts.websockets.connect", new_callable=AsyncMock)
+async def test_connect_sends_bos(mock_connect):
+    ws = AsyncMock()
+    mock_connect.return_value = ws
+
+    tts = ElevenLabsTTS()
+    await tts.connect("voice-1", "model-1", "key-1")
+
+    mock_connect.assert_awaited_once()
+    url = mock_connect.call_args[0][0]
+    assert "voice-1" in url
+    assert "model_id=model-1" in url
+    assert "output_format=pcm_24000" in url
+
+    bos = json.loads(ws.send.call_args[0][0])
+    assert bos["text"] == " "
+    assert "voice_settings" in bos
+    assert "generation_config" in bos
+
+
+# ---------------------------------------------------------------------------
+# send_text
+# ---------------------------------------------------------------------------
+
+
+@patch("voice_assistant.elevenlabs_tts.websockets.connect", new_callable=AsyncMock)
+async def test_send_text(mock_connect):
+    ws = AsyncMock()
+    mock_connect.return_value = ws
+
+    tts = ElevenLabsTTS()
+    await tts.connect("v", "m", "k")
+    ws.send.reset_mock()
+
+    await tts.send_text("Hello world ")
+
+    msg = json.loads(ws.send.call_args[0][0])
+    assert msg["text"] == "Hello world "
+    assert msg["try_trigger_generation"] is True
+
+
+# ---------------------------------------------------------------------------
+# flush
+# ---------------------------------------------------------------------------
+
+
+@patch("voice_assistant.elevenlabs_tts.websockets.connect", new_callable=AsyncMock)
+async def test_flush_sends_empty_text(mock_connect):
+    ws = AsyncMock()
+    mock_connect.return_value = ws
+
+    tts = ElevenLabsTTS()
+    await tts.connect("v", "m", "k")
+    ws.send.reset_mock()
+
+    await tts.flush()
+
+    msg = json.loads(ws.send.call_args[0][0])
+    assert msg["text"] == ""
+
+
+# ---------------------------------------------------------------------------
+# receive_audio
+# ---------------------------------------------------------------------------
+
+
+@patch("voice_assistant.elevenlabs_tts.websockets.connect", new_callable=AsyncMock)
+async def test_receive_audio_yields_pcm_chunks(mock_connect):
+    ws = AsyncMock()
+    ws.__aiter__ = lambda self: self
+    chunks = [_audio_msg(b"\x00\x01"), _audio_msg(b"\x02\x03"), _final_msg()]
+    ws.__anext__ = AsyncMock(side_effect=chunks + [StopAsyncIteration])
+    mock_connect.return_value = ws
+
+    tts = ElevenLabsTTS()
+    await tts.connect("v", "m", "k")
+
+    received = []
+    async for chunk in tts.receive_audio():
+        received.append(chunk)
+
+    assert received == [b"\x00\x01", b"\x02\x03"]
+
+
+@patch("voice_assistant.elevenlabs_tts.websockets.connect", new_callable=AsyncMock)
+async def test_receive_audio_skips_empty_audio_field(mock_connect):
+    ws = AsyncMock()
+    ws.__aiter__ = lambda self: self
+    chunks = [
+        json.dumps({"audio": None}),
+        _audio_msg(b"\x01"),
+        _final_msg(),
+    ]
+    ws.__anext__ = AsyncMock(side_effect=chunks + [StopAsyncIteration])
+    mock_connect.return_value = ws
+
+    tts = ElevenLabsTTS()
+    await tts.connect("v", "m", "k")
+
+    received = []
+    async for chunk in tts.receive_audio():
+        received.append(chunk)
+
+    assert received == [b"\x01"]
+
+
+# ---------------------------------------------------------------------------
+# interrupt
+# ---------------------------------------------------------------------------
+
+
+@patch("voice_assistant.elevenlabs_tts.websockets.connect", new_callable=AsyncMock)
+async def test_interrupt_closes_websocket(mock_connect):
+    ws = AsyncMock()
+    mock_connect.return_value = ws
+
+    tts = ElevenLabsTTS()
+    await tts.connect("v", "m", "k")
+
+    await tts.interrupt()
+
+    ws.close.assert_awaited_once()
+    assert tts._ws is None
+
+
+async def test_receive_audio_handles_connection_closed():
+    """receive_audio handles ConnectionClosed gracefully."""
+    import websockets
+
+    ws = AsyncMock()
+    ws.__aiter__ = lambda self: self
+    ws.__anext__ = AsyncMock(side_effect=websockets.ConnectionClosed(None, None))
+
+    tts = ElevenLabsTTS()
+    tts._ws = ws  # inject directly, skip connect
+
+    received = [c async for c in tts.receive_audio()]
+    assert received == []
+
+
+@patch("voice_assistant.elevenlabs_tts.websockets.connect", new_callable=AsyncMock)
+async def test_interrupt_handles_close_error(mock_connect):
+    ws = AsyncMock()
+    ws.close.side_effect = RuntimeError("already closed")
+    mock_connect.return_value = ws
+
+    tts = ElevenLabsTTS()
+    await tts.connect("v", "m", "k")
+
+    await tts.interrupt()  # should not raise
+
+    assert tts._ws is None
+
+
+# ---------------------------------------------------------------------------
+# Methods are safe to call without connect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,args",
+    [
+        ("send_text", ("hello",)),
+        ("flush", ()),
+        ("interrupt", ()),
+    ],
+)
+async def test_method_without_connect_is_noop(method, args):
+    tts = ElevenLabsTTS()
+    await getattr(tts, method)(*args)  # should not raise
+
+
+async def test_receive_audio_without_connect_yields_nothing():
+    tts = ElevenLabsTTS()
+    assert [c async for c in tts.receive_audio()] == []

--- a/tests/unit/test_elevenlabs_tts.py
+++ b/tests/unit/test_elevenlabs_tts.py
@@ -30,6 +30,25 @@ def _final_msg() -> str:
 # ---------------------------------------------------------------------------
 
 
+async def test_connect_times_out_when_unreachable():
+    """connect() raises TimeoutError instead of hanging if ElevenLabs is unreachable."""
+    import asyncio
+
+    async def _never_connect(*a, **kw):
+        await asyncio.sleep(10)
+
+    tts = ElevenLabsTTS()
+    with patch("voice_assistant.elevenlabs_tts._CONNECT_TIMEOUT", 0.01):
+        with patch(
+            "voice_assistant.elevenlabs_tts.websockets.connect",
+            side_effect=_never_connect,
+        ):
+            with pytest.raises(asyncio.TimeoutError):
+                await tts.connect("v", "m", "k")
+
+    assert not tts.is_connected
+
+
 @patch("voice_assistant.elevenlabs_tts.websockets.connect", new_callable=AsyncMock)
 async def test_connect_sends_bos(mock_connect):
     ws = AsyncMock()
@@ -171,10 +190,30 @@ async def test_receive_audio_handles_connection_closed():
     assert not tts.is_connected
 
 
+async def test_receive_audio_clears_ws_on_unexpected_error():
+    """A non-ConnectionClosed error (e.g. malformed JSON) still clears _ws
+    so subsequent send_text() doesn't write to a dead socket."""
+    ws = AsyncMock()
+    ws.__aiter__ = lambda self: self
+    ws.__anext__ = AsyncMock(return_value="not-valid-json{")
+
+    tts = ElevenLabsTTS()
+    tts._ws = ws
+
+    with pytest.raises(json.JSONDecodeError):
+        async for _ in tts.receive_audio():
+            pass
+
+    assert not tts.is_connected
+
+
 @patch("voice_assistant.elevenlabs_tts.websockets.connect", new_callable=AsyncMock)
 async def test_interrupt_handles_close_error(mock_connect):
+    """A close() failure from the underlying websocket is logged, not raised."""
+    import websockets
+
     ws = AsyncMock()
-    ws.close.side_effect = RuntimeError("already closed")
+    ws.close.side_effect = websockets.InvalidState("already closed")
     mock_connect.return_value = ws
 
     tts = ElevenLabsTTS()

--- a/uv.lock
+++ b/uv.lock
@@ -3162,6 +3162,7 @@ source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },
     { name = "google-adk" },
+    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -3177,6 +3178,7 @@ dev = [
 requires-dist = [
     { name = "audioop-lts", specifier = ">=0.2.1" },
     { name = "google-adk", specifier = ">=1.28.0" },
+    { name = "websockets", specifier = ">=15.0.1" },
 ]
 
 [package.metadata.requires-dev]

--- a/voice_assistant/agent.py
+++ b/voice_assistant/agent.py
@@ -21,9 +21,15 @@ from .tools import ALL_TOOLS
 
 
 class _DualModelGemini(Gemini):
-    """Gemini wrapper that uses one model for text and another for live audio."""
+    """Gemini wrapper that uses one model for text and another for live audio.
 
-    live_model: str = GEMINI_LIVE_MODEL
+    When the voice backend is ElevenLabs, the live model stays on the
+    standard text model (no native audio) because TTS is handled externally.
+    """
+
+    live_model: str = (
+        GEMINI_MODEL if settings.voice_backend == "elevenlabs" else GEMINI_LIVE_MODEL
+    )
 
     @contextlib.asynccontextmanager
     async def connect(

--- a/voice_assistant/call_handler.py
+++ b/voice_assistant/call_handler.py
@@ -82,6 +82,14 @@ async def handle_media_stream(websocket: WebSocket) -> None:
     tts: ElevenLabsTTS | None = None
     if use_elevenlabs:
         tts = ElevenLabsTTS()
+        # Eagerly open the ElevenLabs WebSocket so the TLS+WS handshake
+        # completes concurrently with ADK session setup rather than blocking
+        # the first audio chunk.
+        await tts.connect(
+            voice_id=profile["elevenlabs_voice_id"],
+            model_id=settings.elevenlabs_model_id,
+            api_key=settings.elevenlabs_api_key,
+        )
 
     sid_holder: list[str | None] = [None]
     twilio_task = asyncio.create_task(
@@ -249,25 +257,74 @@ async def _handle_interrupt(
             state.interrupt_latched = True
         else:
             log.info("Caller interrupted but streamSid not available yet")
-    if tts is not None:
-        await tts.interrupt()
+        # Only tear down the TTS session on the leading-edge interrupt;
+        # repeat "interrupted" events within the same barge-in window
+        # should not re-close an already-closed socket.
+        if tts is not None:
+            await tts.interrupt()
     state.draining = False
     return True
 
 
-def _detect_farewell(event: Event, state: _CallLoopState) -> None:
-    """Detect farewell phrases in agent output to trigger drain."""
-    if not (hasattr(event, "output_transcription") and event.output_transcription):
+def _mark_draining_if_farewell(text: str, state: _CallLoopState) -> None:
+    """Set ``state.draining`` when ``text`` contains a farewell phrase."""
+    if not text:
         return
-    if not (
-        hasattr(event.output_transcription, "text") and event.output_transcription.text
-    ):
-        return
-    text = event.output_transcription.text
     log.debug("Agent said: %s", text)
     if not state.draining and any(fp in text.lower() for fp in FAREWELL_PHRASES):
         log.info("Farewell phrase detected in agent speech — draining")
         state.draining = True
+
+
+def _detect_farewell(event: Event, state: _CallLoopState) -> None:
+    """Detect farewell phrases in the Gemini audio-mode output transcription."""
+    transcription = getattr(event, "output_transcription", None)
+    text = getattr(transcription, "text", None) if transcription else None
+    if text:
+        _mark_draining_if_farewell(text, state)
+
+
+def _detect_farewell_from_text(event: Event, state: _CallLoopState) -> None:
+    """Detect farewell phrases in text-mode content (ElevenLabs path)."""
+    _mark_draining_if_farewell(_extract_text(event), state)
+
+
+async def _send_pcm_chunk(
+    ws: WebSocket,
+    sid_holder: list[str | None],
+    pcm: bytes,
+    mark_name: str | None = None,
+) -> bool:
+    """Forward one PCM chunk to Twilio as mulaw. Returns True if sent."""
+    stream_sid = sid_holder[0]
+    if not stream_sid:
+        await asyncio.sleep(0.05)
+        stream_sid = sid_holder[0]
+    if not stream_sid:
+        log.debug("No stream SID yet, dropping audio chunk")
+        return False
+
+    mulaw_b64 = gemini_pcm_to_twilio_mulaw_b64(pcm)
+    await ws.send_text(
+        json.dumps(
+            {
+                "event": "media",
+                "streamSid": stream_sid,
+                "media": {"payload": mulaw_b64},
+            }
+        )
+    )
+    if mark_name:
+        await ws.send_text(
+            json.dumps(
+                {
+                    "event": "mark",
+                    "streamSid": stream_sid,
+                    "mark": {"name": mark_name},
+                }
+            )
+        )
+    return True
 
 
 async def _relay_audio(
@@ -282,34 +339,10 @@ async def _relay_audio(
     for part in event.content.parts:
         if not (part.inline_data and part.inline_data.data):
             continue
-        stream_sid = sid_holder[0]
-        if not stream_sid:
-            await asyncio.sleep(0.05)
-            stream_sid = sid_holder[0]
-        if not stream_sid:
-            log.debug("No stream SID yet, dropping audio chunk")
-            continue
-
-        has_audio = True
-        mulaw_b64 = gemini_pcm_to_twilio_mulaw_b64(part.inline_data.data)
-        await ws.send_text(
-            json.dumps(
-                {
-                    "event": "media",
-                    "streamSid": stream_sid,
-                    "media": {"payload": mulaw_b64},
-                }
-            )
-        )
-        await ws.send_text(
-            json.dumps(
-                {
-                    "event": "mark",
-                    "streamSid": stream_sid,
-                    "mark": {"name": "adk-chunk"},
-                }
-            )
-        )
+        if await _send_pcm_chunk(
+            ws, sid_holder, part.inline_data.data, mark_name="adk-chunk"
+        ):
+            has_audio = True
     return has_audio
 
 
@@ -317,20 +350,7 @@ def _extract_text(event: Event) -> str:
     """Extract text content from an ADK event's parts (used in text mode)."""
     if not (event.content and event.content.parts):
         return ""
-    return "".join(
-        part.text for part in event.content.parts if hasattr(part, "text") and part.text
-    )
-
-
-def _detect_farewell_from_text(event: Event, state: _CallLoopState) -> None:
-    """Detect farewell phrases in text content (ElevenLabs / text-mode path)."""
-    text = _extract_text(event)
-    if not text:
-        return
-    log.debug("Agent said: %s", text)
-    if not state.draining and any(fp in text.lower() for fp in FAREWELL_PHRASES):
-        log.info("Farewell phrase detected in agent text — draining")
-        state.draining = True
+    return "".join(part.text for part in event.content.parts if part.text)
 
 
 async def _tts_audio_to_twilio(
@@ -340,33 +360,9 @@ async def _tts_audio_to_twilio(
 ) -> None:
     """Background task: read PCM audio from ElevenLabs and forward to Twilio."""
     async for pcm_chunk in tts.receive_audio():
-        stream_sid = sid_holder[0]
-        if not stream_sid:
-            await asyncio.sleep(0.05)
-            stream_sid = sid_holder[0]
-        if not stream_sid:
-            log.debug("No stream SID yet, dropping ElevenLabs audio chunk")
-            continue
-
-        mulaw_b64 = gemini_pcm_to_twilio_mulaw_b64(pcm_chunk)
-        await ws.send_text(
-            json.dumps(
-                {
-                    "event": "media",
-                    "streamSid": stream_sid,
-                    "media": {"payload": mulaw_b64},
-                }
-            )
-        )
-        await ws.send_text(
-            json.dumps(
-                {
-                    "event": "mark",
-                    "streamSid": stream_sid,
-                    "mark": {"name": "tts-chunk"},
-                }
-            )
-        )
+        # No mark on TTS chunks — unlike the goodbye-done mark, these have
+        # no consumer and Twilio echoes them back as noise events.
+        await _send_pcm_chunk(ws, sid_holder, pcm_chunk)
 
 
 async def _finish_drain(
@@ -418,9 +414,8 @@ async def _adk_to_twilio(
             _process_input_transcription(event, state)
 
             if await _handle_interrupt(event, state, ws, sid_holder, tts=tts):
-                if tts_receiver and not tts_receiver.done():
-                    tts_receiver.cancel()
-                    tts_receiver = None
+                await _cancel_tts_receiver(tts_receiver)
+                tts_receiver = None
                 continue
             if state.interrupt_latched:
                 continue
@@ -430,6 +425,7 @@ async def _adk_to_twilio(
                 _detect_farewell_from_text(event, state)
                 text = _extract_text(event)
                 if text:
+                    # Reconnect after a prior barge-in closed the socket.
                     if not tts.is_connected:
                         profile = settings.language_profile()
                         await tts.connect(
@@ -437,6 +433,10 @@ async def _adk_to_twilio(
                             model_id=settings.elevenlabs_model_id,
                             api_key=settings.elevenlabs_api_key,
                         )
+                    # Receiver is (re)started once per TTS session —
+                    # either on the very first text chunk of the call, or
+                    # after a post-interrupt reconnect.
+                    if tts_receiver is None or tts_receiver.done():
                         tts_receiver = asyncio.create_task(
                             _tts_audio_to_twilio(tts, ws, sid_holder)
                         )
@@ -470,5 +470,17 @@ async def _adk_to_twilio(
     finally:
         if tts is not None:
             await tts.interrupt()
-        if tts_receiver and not tts_receiver.done():
-            tts_receiver.cancel()
+        await _cancel_tts_receiver(tts_receiver)
+
+
+async def _cancel_tts_receiver(task: asyncio.Task | None) -> None:
+    """Cancel a TTS receiver task and wait for it to fully unwind.
+
+    Awaiting the cancellation prevents one final ``ws.send_text`` from
+    firing after a Twilio ``clear`` (audible bleed on barge-in) and
+    prevents zombie tasks from piling up under load.
+    """
+    if task is None or task.done():
+        return
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)

--- a/voice_assistant/call_handler.py
+++ b/voice_assistant/call_handler.py
@@ -430,7 +430,7 @@ async def _adk_to_twilio(
                 _detect_farewell_from_text(event, state)
                 text = _extract_text(event)
                 if text:
-                    if tts._ws is None:
+                    if not tts.is_connected:
                         profile = settings.language_profile()
                         await tts.connect(
                             voice_id=profile["elevenlabs_voice_id"],

--- a/voice_assistant/call_handler.py
+++ b/voice_assistant/call_handler.py
@@ -27,6 +27,7 @@ from google.genai import types
 from .agent import root_agent
 from .audio import gemini_pcm_to_twilio_mulaw_b64, twilio_mulaw_to_gemini_pcm
 from .config import FAREWELL_PHRASES, settings
+from .elevenlabs_tts import ElevenLabsTTS
 
 log = logging.getLogger(__name__)
 
@@ -48,16 +49,21 @@ async def handle_media_stream(websocket: WebSocket) -> None:
     runner = InMemoryRunner(agent=root_agent, app_name="voice_assistant")
     live_queue = LiveRequestQueue()
 
-    run_config = RunConfig(
-        response_modalities=["AUDIO"],
-        speech_config=types.SpeechConfig(
-            voice_config=types.VoiceConfig(
-                prebuilt_voice_config=types.PrebuiltVoiceConfig(
-                    voice_name=profile["voice_name"],
+    use_elevenlabs = settings.voice_backend == "elevenlabs"
+
+    if use_elevenlabs:
+        run_config = RunConfig(response_modalities=["TEXT"])
+    else:
+        run_config = RunConfig(
+            response_modalities=["AUDIO"],
+            speech_config=types.SpeechConfig(
+                voice_config=types.VoiceConfig(
+                    prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                        voice_name=profile["voice_name"],
+                    )
                 )
-            )
-        ),
-    )
+            ),
+        )
 
     user_id = "twilio_caller"
     session = await runner.session_service.create_session(
@@ -73,6 +79,10 @@ async def handle_media_stream(websocket: WebSocket) -> None:
         )
     )
 
+    tts: ElevenLabsTTS | None = None
+    if use_elevenlabs:
+        tts = ElevenLabsTTS()
+
     sid_holder: list[str | None] = [None]
     twilio_task = asyncio.create_task(
         _twilio_to_adk(websocket, live_queue, sid_holder, call_end_event)
@@ -87,6 +97,7 @@ async def handle_media_stream(websocket: WebSocket) -> None:
             run_config,
             sid_holder,
             call_end_event,
+            tts=tts,
         )
     )
 
@@ -225,6 +236,7 @@ async def _handle_interrupt(
     state: _CallLoopState,
     ws: WebSocket,
     sid_holder: list[str | None],
+    tts: ElevenLabsTTS | None = None,
 ) -> bool:
     """Send Twilio ``clear`` on barge-in. Returns True to skip the event."""
     if not getattr(event, "interrupted", None):
@@ -237,6 +249,8 @@ async def _handle_interrupt(
             state.interrupt_latched = True
         else:
             log.info("Caller interrupted but streamSid not available yet")
+    if tts is not None:
+        await tts.interrupt()
     state.draining = False
     return True
 
@@ -299,6 +313,62 @@ async def _relay_audio(
     return has_audio
 
 
+def _extract_text(event: Event) -> str:
+    """Extract text content from an ADK event's parts (used in text mode)."""
+    if not (event.content and event.content.parts):
+        return ""
+    return "".join(
+        part.text for part in event.content.parts if hasattr(part, "text") and part.text
+    )
+
+
+def _detect_farewell_from_text(event: Event, state: _CallLoopState) -> None:
+    """Detect farewell phrases in text content (ElevenLabs / text-mode path)."""
+    text = _extract_text(event)
+    if not text:
+        return
+    log.debug("Agent said: %s", text)
+    if not state.draining and any(fp in text.lower() for fp in FAREWELL_PHRASES):
+        log.info("Farewell phrase detected in agent text — draining")
+        state.draining = True
+
+
+async def _tts_audio_to_twilio(
+    tts: ElevenLabsTTS,
+    ws: WebSocket,
+    sid_holder: list[str | None],
+) -> None:
+    """Background task: read PCM audio from ElevenLabs and forward to Twilio."""
+    async for pcm_chunk in tts.receive_audio():
+        stream_sid = sid_holder[0]
+        if not stream_sid:
+            await asyncio.sleep(0.05)
+            stream_sid = sid_holder[0]
+        if not stream_sid:
+            log.debug("No stream SID yet, dropping ElevenLabs audio chunk")
+            continue
+
+        mulaw_b64 = gemini_pcm_to_twilio_mulaw_b64(pcm_chunk)
+        await ws.send_text(
+            json.dumps(
+                {
+                    "event": "media",
+                    "streamSid": stream_sid,
+                    "media": {"payload": mulaw_b64},
+                }
+            )
+        )
+        await ws.send_text(
+            json.dumps(
+                {
+                    "event": "mark",
+                    "streamSid": stream_sid,
+                    "mark": {"name": "tts-chunk"},
+                }
+            )
+        )
+
+
 async def _finish_drain(
     ws: WebSocket,
     sid_holder: list[str | None],
@@ -334,8 +404,10 @@ async def _adk_to_twilio(
     run_config: RunConfig,
     sid_holder: list[str | None],
     call_end_event: asyncio.Event,
+    tts: ElevenLabsTTS | None = None,
 ) -> None:
     state = _CallLoopState()
+    tts_receiver: asyncio.Task | None = None
     try:
         async for event in runner.run_live(
             user_id=user_id,
@@ -345,17 +417,47 @@ async def _adk_to_twilio(
         ):
             _process_input_transcription(event, state)
 
-            if await _handle_interrupt(event, state, ws, sid_holder):
+            if await _handle_interrupt(event, state, ws, sid_holder, tts=tts):
+                if tts_receiver and not tts_receiver.done():
+                    tts_receiver.cancel()
+                    tts_receiver = None
                 continue
             if state.interrupt_latched:
                 continue
 
-            _detect_farewell(event, state)
-            has_audio = await _relay_audio(event, ws, sid_holder)
+            if tts is not None:
+                # ElevenLabs text-mode path
+                _detect_farewell_from_text(event, state)
+                text = _extract_text(event)
+                if text:
+                    if tts._ws is None:
+                        profile = settings.language_profile()
+                        await tts.connect(
+                            voice_id=profile["elevenlabs_voice_id"],
+                            model_id=settings.elevenlabs_model_id,
+                            api_key=settings.elevenlabs_api_key,
+                        )
+                        tts_receiver = asyncio.create_task(
+                            _tts_audio_to_twilio(tts, ws, sid_holder)
+                        )
+                    await tts.send_text(text)
 
-            if state.draining and not has_audio:
-                await _finish_drain(ws, sid_holder, call_end_event)
-                break
+                if state.draining:
+                    await tts.flush()
+                    if tts_receiver:
+                        await tts_receiver
+                        tts_receiver = None
+                    await _finish_drain(ws, sid_holder, call_end_event)
+                    break
+            else:
+                # Gemini native-audio path
+                _detect_farewell(event, state)
+                has_audio = await _relay_audio(event, ws, sid_holder)
+
+                if state.draining and not has_audio:
+                    await _finish_drain(ws, sid_holder, call_end_event)
+                    break
+
             if call_end_event.is_set():
                 break
 
@@ -365,3 +467,8 @@ async def _adk_to_twilio(
         log.debug("Twilio WebSocket disconnected during send")
     except Exception as exc:
         log.error("Error in adk->twilio loop: %s", exc)
+    finally:
+        if tts is not None:
+            await tts.interrupt()
+        if tts_receiver and not tts_receiver.done():
+            tts_receiver.cancel()

--- a/voice_assistant/config.py
+++ b/voice_assistant/config.py
@@ -153,8 +153,15 @@ class Settings:
         default_factory=lambda: os.getenv("ELEVENLABS_MODEL_ID", "eleven_turbo_v2_5")
     )
 
+    _VALID_VOICE_BACKENDS = {"gemini", "elevenlabs"}
+
     def validate(self, *, require_twilio: bool = True) -> None:
         """Call on startup to fail early with a clear message if config is missing."""
+        if self.voice_backend not in self._VALID_VOICE_BACKENDS:
+            raise EnvironmentError(
+                f"VOICE_BACKEND={self.voice_backend!r} is not valid. "
+                f"Choose one of: {', '.join(sorted(self._VALID_VOICE_BACKENDS))}"
+            )
         missing = []
         if require_twilio:
             if not self.twilio_account_sid:

--- a/voice_assistant/config.py
+++ b/voice_assistant/config.py
@@ -23,6 +23,7 @@ LANGUAGE_PROFILES: dict[str, dict] = {
     "de-CH": {
         "display": "Swiss German",
         "voice_name": "Leda",
+        "elevenlabs_voice_id": "onwK4e9ZLuTAKqWW03F9",  # Daniel
         "greeting": (
             "Grüezi! Sie sind mit dem Kundendienst verbunden. "
             "Wie kann ich Ihnen heute helfen?"
@@ -35,6 +36,7 @@ LANGUAGE_PROFILES: dict[str, dict] = {
     "de-DE": {
         "display": "Standard German",
         "voice_name": "Leda",
+        "elevenlabs_voice_id": "onwK4e9ZLuTAKqWW03F9",  # Daniel
         "greeting": (
             "Hallo! Sie sind mit dem Kundendienst verbunden. Wie kann ich Ihnen helfen?"
         ),
@@ -46,6 +48,7 @@ LANGUAGE_PROFILES: dict[str, dict] = {
     "fr-CH": {
         "display": "Swiss French",
         "voice_name": "Aoede",
+        "elevenlabs_voice_id": "TX3LPaxmHKxFdv7VOQHJ",  # Liam
         "greeting": (
             "Bonjour! Vous êtes en contact avec notre service clientèle. "
             "Comment puis-je vous aider aujourd'hui?"
@@ -58,6 +61,7 @@ LANGUAGE_PROFILES: dict[str, dict] = {
     "it-CH": {
         "display": "Swiss Italian",
         "voice_name": "Zephyr",
+        "elevenlabs_voice_id": "bIHbv24MWmeRgasZH58o",  # Will
         "greeting": (
             "Buongiorno! Benvenuto al servizio clienti. Come posso aiutarla oggi?"
         ),
@@ -136,6 +140,19 @@ class Settings:
         default_factory=lambda: os.getenv("DEFAULT_LANGUAGE", "de-CH")
     )
 
+    # Voice backend: "gemini" (default) or "elevenlabs"
+    voice_backend: str = field(
+        default_factory=lambda: os.getenv("VOICE_BACKEND", "gemini")
+    )
+
+    # ElevenLabs (required when voice_backend == "elevenlabs")
+    elevenlabs_api_key: str = field(
+        default_factory=lambda: os.getenv("ELEVENLABS_API_KEY", "")
+    )
+    elevenlabs_model_id: str = field(
+        default_factory=lambda: os.getenv("ELEVENLABS_MODEL_ID", "eleven_turbo_v2_5")
+    )
+
     def validate(self, *, require_twilio: bool = True) -> None:
         """Call on startup to fail early with a clear message if config is missing."""
         missing = []
@@ -148,6 +165,8 @@ class Settings:
                 missing.append("TWILIO_PHONE_NUMBER")
         if not self.google_api_key and not self.google_cloud_project:
             missing.append("GOOGLE_API_KEY (or GOOGLE_CLOUD_PROJECT for Vertex AI)")
+        if self.voice_backend == "elevenlabs" and not self.elevenlabs_api_key:
+            missing.append("ELEVENLABS_API_KEY")
         if missing:
             raise EnvironmentError(
                 "Missing required environment variables:\n  "

--- a/voice_assistant/elevenlabs_tts.py
+++ b/voice_assistant/elevenlabs_tts.py
@@ -1,0 +1,102 @@
+"""
+Async streaming TTS client for ElevenLabs WebSocket API.
+
+Opens a WebSocket to ElevenLabs' ``stream-input`` endpoint, streams text
+chunks in, and yields raw PCM audio chunks back.  Output format is
+``pcm_24000`` (16-bit LE mono @ 24 kHz) — the same format Gemini Live
+produces, so the existing ``gemini_pcm_to_twilio_mulaw_b64()`` converter
+works unchanged.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from collections.abc import AsyncGenerator
+
+import websockets
+
+log = logging.getLogger(__name__)
+
+_BASE_URL = "wss://api.elevenlabs.io/v1/text-to-speech"
+_OUTPUT_FORMAT = "pcm_24000"
+
+
+class ElevenLabsTTS:
+    """One-shot streaming TTS session.
+
+    Typical lifecycle::
+
+        tts = ElevenLabsTTS()
+        await tts.connect(voice_id, model_id, api_key)
+        await tts.send_text("Hello ")
+        await tts.send_text("world!")
+        await tts.flush()
+        async for pcm_chunk in tts.receive_audio():
+            ...  # forward to Twilio
+    """
+
+    def __init__(self) -> None:
+        self._ws: websockets.ClientConnection | None = None
+
+    async def connect(
+        self,
+        voice_id: str,
+        model_id: str,
+        api_key: str,
+    ) -> None:
+        """Open the WebSocket and send the BOS (beginning-of-stream) message."""
+        url = (
+            f"{_BASE_URL}/{voice_id}/stream-input"
+            f"?model_id={model_id}&output_format={_OUTPUT_FORMAT}"
+        )
+        self._ws = await websockets.connect(
+            url, additional_headers={"xi-api-key": api_key}
+        )
+        bos = {
+            "text": " ",
+            "voice_settings": {"stability": 0.5, "similarity_boost": 0.75},
+            "generation_config": {"chunk_length_schedule": [50]},
+        }
+        await self._ws.send(json.dumps(bos))
+        log.debug("ElevenLabs TTS session opened [voice=%s]", voice_id)
+
+    async def send_text(self, text: str) -> None:
+        """Stream a text chunk to ElevenLabs for synthesis."""
+        if self._ws is None:
+            return
+        await self._ws.send(json.dumps({"text": text, "try_trigger_generation": True}))
+
+    async def flush(self) -> None:
+        """Signal end of text input — triggers generation of remaining audio."""
+        if self._ws is None:
+            return
+        await self._ws.send(json.dumps({"text": ""}))
+
+    async def receive_audio(self) -> AsyncGenerator[bytes]:
+        """Yield raw PCM audio chunks (24 kHz, 16-bit LE) as they arrive."""
+        if self._ws is None:
+            return
+        try:
+            async for raw in self._ws:
+                msg = json.loads(raw)
+                if msg.get("isFinal"):
+                    break
+                audio_b64 = msg.get("audio")
+                if audio_b64:
+                    yield base64.b64decode(audio_b64)
+        except websockets.ConnectionClosed:
+            log.debug("ElevenLabs WebSocket closed during receive")
+
+    async def interrupt(self) -> None:
+        """Abort the current TTS session (used for barge-in)."""
+        if self._ws is None:
+            return
+        try:
+            await self._ws.close()
+        except Exception:
+            pass
+        finally:
+            self._ws = None
+            log.debug("ElevenLabs TTS session interrupted")

--- a/voice_assistant/elevenlabs_tts.py
+++ b/voice_assistant/elevenlabs_tts.py
@@ -10,6 +10,7 @@ works unchanged.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
@@ -21,6 +22,8 @@ log = logging.getLogger(__name__)
 
 _BASE_URL = "wss://api.elevenlabs.io/v1/text-to-speech"
 _OUTPUT_FORMAT = "pcm_24000"
+# Max seconds to wait for the ElevenLabs WebSocket handshake before giving up.
+_CONNECT_TIMEOUT = 5.0
 
 
 class ElevenLabsTTS:
@@ -55,8 +58,9 @@ class ElevenLabsTTS:
             f"{_BASE_URL}/{voice_id}/stream-input"
             f"?model_id={model_id}&output_format={_OUTPUT_FORMAT}"
         )
-        self._ws = await websockets.connect(
-            url, additional_headers={"xi-api-key": api_key}
+        self._ws = await asyncio.wait_for(
+            websockets.connect(url, additional_headers={"xi-api-key": api_key}),
+            timeout=_CONNECT_TIMEOUT,
         )
         bos = {
             "text": " ",
@@ -91,8 +95,12 @@ class ElevenLabsTTS:
                 if audio_b64:
                     yield base64.b64decode(audio_b64)
         except websockets.ConnectionClosed:
-            self._ws = None
             log.debug("ElevenLabs WebSocket closed during receive")
+        finally:
+            # Always clear _ws on exit so a broken socket (e.g. malformed
+            # JSON from the server) doesn't leave subsequent send_text()
+            # writing to a dead connection.
+            self._ws = None
 
     async def interrupt(self) -> None:
         """Abort the current TTS session (used for barge-in)."""
@@ -100,8 +108,8 @@ class ElevenLabsTTS:
             return
         try:
             await self._ws.close()
-        except Exception:
-            pass
+        except websockets.WebSocketException as exc:
+            log.debug("ElevenLabs WebSocket close raised %s", exc)
         finally:
             self._ws = None
             log.debug("ElevenLabs TTS session interrupted")

--- a/voice_assistant/elevenlabs_tts.py
+++ b/voice_assistant/elevenlabs_tts.py
@@ -40,6 +40,10 @@ class ElevenLabsTTS:
     def __init__(self) -> None:
         self._ws: websockets.ClientConnection | None = None
 
+    @property
+    def is_connected(self) -> bool:
+        return self._ws is not None
+
     async def connect(
         self,
         voice_id: str,
@@ -87,6 +91,7 @@ class ElevenLabsTTS:
                 if audio_b64:
                     yield base64.b64decode(audio_b64)
         except websockets.ConnectionClosed:
+            self._ws = None
             log.debug("ElevenLabs WebSocket closed during receive")
 
     async def interrupt(self) -> None:


### PR DESCRIPTION
## Summary

- Adds ElevenLabs as an alternative TTS backend, selectable via `VOICE_BACKEND=elevenlabs`
- When active, Gemini handles STT+LLM in text mode (`response_modalities=["TEXT"]`) while ElevenLabs streams TTS via its WebSocket API (`pcm_24000` output reuses existing mulaw conversion)
- The default Gemini native-audio path (`VOICE_BACKEND=gemini`) is completely unchanged

## Changes

- **`voice_assistant/elevenlabs_tts.py`** (new) — async streaming TTS client wrapping the ElevenLabs `stream-input` WebSocket endpoint, with `connect`, `send_text`, `flush`, `receive_audio`, and `interrupt` for barge-in
- **`voice_assistant/config.py`** — new settings (`voice_backend`, `elevenlabs_api_key`, `elevenlabs_model_id`), `elevenlabs_voice_id` per language profile, validation
- **`voice_assistant/agent.py`** — `_DualModelGemini` uses text model (not native-audio) when ElevenLabs is the backend
- **`voice_assistant/call_handler.py`** — branches `RunConfig` and the `_adk_to_twilio` loop for text vs audio mode; adds `_extract_text`, `_detect_farewell_from_text`, `_tts_audio_to_twilio` helpers; barge-in calls `tts.interrupt()`
- **`pyproject.toml`** — adds `websockets` dependency
- **`.env.example`** — documents `VOICE_BACKEND`, `ELEVENLABS_API_KEY`, `ELEVENLABS_MODEL_ID`
- **`docs/plans/`** — implementation plan

## Test plan

- [x] 132 unit tests pass (`just pytest`), 100% coverage
- [x] Lint and format clean (`just fmt`, pre-commit hooks)
- [x] Existing Gemini path regression: all 100 original tests still pass
- [ ] Manual: set `VOICE_BACKEND=elevenlabs` with a valid API key, call the Twilio number, verify ElevenLabs voice output
- [ ] Manual: verify barge-in works (caller interrupts agent mid-speech)
- [ ] Manual: verify farewell detection still ends the call gracefully