### PR TITLE
feat: configurable persona scoping with Velo-Händler demo (closes #9)

### DIFF
--- a/docs/brainstorms/2026-04-16-persona-scoping-brainstorm.md
+++ b/docs/brainstorms/2026-04-16-persona-scoping-brainstorm.md
@@ -1,0 +1,83 @@
+# Brainstorm: Constrain Agent Persona to Specific Use Case
+
+**Issue:** #9
+**Date:** 2026-04-16
+**Status:** Ready for planning
+
+## What We're Building
+
+A configurable persona system so the voice assistant can be re-pointed to any business demo by swapping a single YAML file. First demo: fictional Swiss bike shop ("Velo-Händler").
+
+The persona constrains the agent's identity, domain knowledge, and scope — off-topic requests are declined gracefully, in-scope questions without data are handled honestly via escalation.
+
+## Why This Approach
+
+**Audience is real customers.** This is not a throwaway demo — it becomes the template for actual paid projects. The abstraction must be clean enough to hand to a new customer onboarding.
+
+**YAML per persona chosen over plain-text or Python modules** because:
+- Structured fields (identity, scope, decline template) are easier to edit for non-developers
+- Scales to many demos without code changes
+- `.env` variable `PERSONA=velo_shop` selects the active persona
+- Per-locale greeting overrides live in the persona YAML (`greetings:` key), applied on top of `LANGUAGE_PROFILES` at runtime
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Config format | One YAML file per persona, selected via `PERSONA` env var | Structured, non-dev friendly, scales |
+| Persona fields | Identity + business facts, allowed topics, out-of-scope decline template | Covers all needs without overreach |
+| Voice/greeting | Stay in LANGUAGE_PROFILES, not persona | Persona is about content/scope, not TTS config |
+| Missing facts behavior | Honestly say "no live access", offer note or escalation | Aligns with #11 (no hallucinated capabilities), leverages existing escalation prompt |
+| First iteration scope | Velo persona only | Smallest diff, prove abstraction works |
+| Decline style | Friendly, persona-specific redirect line in YAML | Not robotic boilerplate — each persona can customize |
+
+## Persona YAML Shape (Sketch)
+
+```yaml
+name: "Velo Züri"
+tagline: "Ihr Velofachgeschäft in Zürich"
+location: "Langstrasse 42, 8004 Zürich"
+
+allowed_topics:
+  - Öffnungszeiten und Standort
+  - Velo-Reparatur und Service
+  - Velo-Verkauf und Beratung
+  - E-Bike Beratung
+  - Zubehör und Ersatzteile
+  - Termin vereinbaren
+
+business_facts:
+  hours: "Mo-Fr 09:00-18:30, Sa 09:00-16:00, So geschlossen"
+  services:
+    - Velo-Reparatur und Wartung
+    - E-Bike Beratung und Verkauf
+    - Kinder- und Stadtvelos
+    - Zubehör (Helme, Schlösser, Lichter)
+  brands:
+    - Canyon
+    - Trek
+    - Specialized
+    - Flyer (E-Bikes)
+  price_range: "Stadtvelos ab CHF 500, E-Bikes ab CHF 2'500"
+
+out_of_scope_decline: >
+  Das liegt leider ausserhalb meines Bereichs — ich bin spezialisiert
+  auf Velo-Themen. Kann ich Ihnen bei etwas rund ums Velo weiterhelfen?
+```
+
+## How It Plugs In
+
+1. `config.py` loads `personas/<PERSONA>.yaml` at startup
+2. `base.txt` gets `{persona_block}` placeholder — persona fields rendered into structured prompt section
+3. Existing escalation prompt stays unchanged (already handles "connect to specialist")
+4. `agent.py` name/description derived from persona name
+
+## Resolved Questions
+
+- **Scope of first iteration?** Velo only. No second stub persona needed.
+- **Voice overrides in persona?** No. Stay in LANGUAGE_PROFILES.
+- **Agent behavior for missing facts?** Honest + escalation. Not improvisation.
+
+## Open Questions
+
+None — ready for planning.

--- a/docs/plans/2026-04-16-001-feat-persona-scoping-velo-demo-plan.md
+++ b/docs/plans/2026-04-16-001-feat-persona-scoping-velo-demo-plan.md
@@ -1,0 +1,226 @@
+---
+title: "feat: Configurable persona scoping (Velo-Händler demo)"
+type: feat
+status: completed
+date: 2026-04-16
+origin: docs/brainstorms/2026-04-16-persona-scoping-brainstorm.md
+---
+
+# feat: Configurable persona scoping (Velo-Händler demo)
+
+## Overview
+
+Add a YAML-based persona system so the voice assistant can be scoped to any business by swapping one config file. First persona: a fictional Swiss bike shop. The agent should answer in-scope questions, honestly decline out-of-scope ones, and never pretend to have capabilities it lacks.
+
+## Problem Statement / Motivation
+
+The current system prompt (`base.txt`) hard-codes a generic "Swiss company customer service" identity. Every demo feels the same. For real customer projects, each deployment needs a distinct persona — name, domain knowledge, scope boundary. There is no abstraction for this today. (see brainstorm: `docs/brainstorms/2026-04-16-persona-scoping-brainstorm.md`)
+
+## Proposed Solution
+
+### New files
+
+```
+voice_assistant/
+  personas/
+    velo_shop.yaml       # first persona — fictional bike shop
+  prompts/
+    base.txt             # refactored — generic scaffolding + {persona_block} slot
+```
+
+### Config flow
+
+1. `PERSONA` env var selects the active persona (e.g. `PERSONA=velo_shop`)
+2. `config.py` loads `personas/{PERSONA}.yaml` at startup, validates required fields, fails fast if missing
+3. YAML fields are rendered into a `{persona_block}` section injected into `base.txt`
+4. `build_instruction()` signature unchanged — existing callers unaffected
+5. `agent.py` name/description derived from persona name
+
+### YAML schema
+
+```yaml
+# Required fields
+name: "Velo Züri"
+tagline: "Ihr Velofachgeschäft in Zürich"
+location: "Langstrasse 42, 8004 Zürich"
+
+allowed_topics:
+  - Öffnungszeiten und Standort
+  - Velo-Reparatur und Service
+  - Velo-Verkauf und Beratung
+  - E-Bike Beratung
+  - Zubehör und Ersatzteile
+  - Termin vereinbaren
+
+business_facts:
+  hours: "Mo-Fr 09:00-18:30, Sa 09:00-16:00, So geschlossen"
+  services:
+    - Velo-Reparatur und Wartung
+    - E-Bike Beratung und Verkauf
+    - Kinder- und Stadtvelos
+    - Zubehör (Helme, Schlösser, Lichter)
+  brands:
+    - Canyon
+    - Trek
+    - Specialized
+    - Flyer (E-Bikes)
+  price_range: "Stadtvelos ab CHF 500, E-Bikes ab CHF 2'500"
+
+out_of_scope_decline: >
+  Das liegt leider ausserhalb meines Bereichs — ich bin spezialisiert
+  auf Velo-Themen. Kann ich Ihnen bei etwas rund ums Velo weiterhelfen?
+
+# Optional — override the generic "Kundendienst" greeting per locale
+greetings:
+  de-CH: >
+    Grüezi! Sie sind mit Velo Züri verbunden.
+    Wie kann ich Ihnen helfen?
+  fr-CH: >
+    Bonjour! Vous êtes en contact avec Velo Züri.
+    Comment puis-je vous aider?
+```
+
+### Prompt composition (refactored `base.txt`)
+
+```
+You are {agent_role} for {persona_name} — {persona_tagline}, located at {persona_location}.
+You are speaking on the phone with a customer.
+
+YOUR EXPERTISE:
+{allowed_topics_formatted}
+
+BUSINESS INFORMATION:
+{business_facts_formatted}
+
+SCOPE RULES:
+- If the customer asks about something NOT in your expertise, respond with:
+  "{out_of_scope_decline}"
+- If the customer asks about something in your expertise but you lack specific
+  data (e.g. current stock, specific pricing), say so honestly and offer to
+  take a note or connect them with a colleague.
+- NEVER pretend to look things up or claim capabilities you do not have.
+
+IMPORTANT RULES:
+- RESPOND IN {language_display}. ...
+[rest of existing rules: language switching, conversation flow, ending the call]
+```
+
+`escalation.txt` stays unchanged — it's generic and complementary (not conflicting) with persona scope rules.
+
+## Technical Considerations
+
+### Startup validation
+
+`config.py` validates the persona YAML at import time:
+- `PERSONA` env var selects a persona by name; when unset, the first available persona YAML file is auto-selected
+- File must exist at `voice_assistant/personas/{PERSONA}.yaml`
+- Required fields: `name`, `allowed_topics`, `out_of_scope_decline`
+- Fail fast with `EnvironmentError` listing what's wrong (matches existing `Settings.validate()` pattern)
+
+### Language switching + persona
+
+The decline template and business facts are written in the persona's primary language. When a caller switches language, Gemini translates on-the-fly — the prompt already instructs "switch to that language immediately." The decline template is guidance, not a literal script. This is sufficient for the demo; per-language decline templates can be added later if needed.
+
+### Greeting override
+
+SpecFlow analysis identified that the existing greeting ("Kundendienst") breaks immersion for a bike shop. The persona YAML has an optional `greetings` dict keyed by locale. If present, `language_profile()` uses it instead of the default. If absent, falls back to existing `LANGUAGE_PROFILES` greeting — backward compatible.
+
+### Escalation vs. decline
+
+These are distinct flows:
+- **Decline** (out-of-scope): "Das ist nicht mein Bereich" → redirect to allowed topics
+- **Escalation** (in-scope, beyond capability): "Ich kann das leider nicht nachschauen — soll ich Sie mit einem Kollegen verbinden?"
+
+`escalation.txt` handles the second. The persona's `out_of_scope_decline` handles the first. No conflict.
+
+## Acceptance Criteria
+
+- [x] `voice_assistant/personas/velo_shop.yaml` exists with all required fields
+- [x] `config.py` loads persona YAML at startup, validates required fields, fails fast if invalid
+- [x] `PERSONA` env var selects the persona file
+- [x] `base.txt` refactored with `{persona_block}` — persona fields injected into system instruction
+- [x] `build_instruction()` output contains persona name, allowed topics, and decline template
+- [x] `agent.py` name/description reflect active persona
+- [x] Out-of-scope questions → graceful decline with persona-specific redirect
+- [x] In-scope questions without data → honest "no live access" + escalation offer
+- [x] Optional `greetings` override works per locale; falls back to `LANGUAGE_PROFILES` if absent
+- [x] Unit tests: YAML loading, validation (missing file, missing fields), prompt composition with persona
+- [x] Existing `test_config.py` tests still pass (language substitution, escalation inclusion, honesty guidance)
+- [ ] Manual test: 3 in-scope + 3 out-of-scope questions behave correctly
+
+## Implementation Steps
+
+### Step 1: Persona YAML + loader (`config.py`)
+
+- Add `PERSONA` field to `Settings` dataclass (default from env var, no fallback)
+- Add `_PERSONAS_DIR = Path(__file__).parent / "personas"`
+- Write `_load_persona(name: str) -> dict` — reads YAML, validates required keys, returns dict
+- Call at module level alongside existing prompt loading
+- Add `pyyaml` dependency via `uv add pyyaml`
+
+Files: `voice_assistant/config.py`, `pyproject.toml`
+
+### Step 2: Create `velo_shop.yaml`
+
+- Write the fictional Velo Züri persona with all fields from schema above
+- Place in `voice_assistant/personas/velo_shop.yaml`
+
+Files: `voice_assistant/personas/velo_shop.yaml`
+
+### Step 3: Refactor `base.txt`
+
+- Replace hard-coded "Swiss company" identity with `{persona_block}` placeholder
+- Add `SCOPE RULES` section with `{out_of_scope_decline}` slot
+- Keep existing rules (language, conversation flow, ending call) unchanged
+- Update `Settings.system_instruction()` to format persona fields into the template
+
+Files: `voice_assistant/prompts/base.txt`, `voice_assistant/config.py`
+
+### Step 4: Greeting override
+
+- In `Settings.language_profile()`, check if persona has `greetings.{lang_code}` and override the greeting field
+- Fallback to existing `LANGUAGE_PROFILES` greeting if persona doesn't specify one
+
+Files: `voice_assistant/config.py`
+
+### Step 5: Update `agent.py`
+
+- Derive agent `name` and `description` from persona (e.g. `name="velo_zueri"`, `description="Velo Züri voice assistant"`)
+
+Files: `voice_assistant/agent.py`
+
+### Step 6: Unit tests
+
+- Test YAML loading succeeds for valid persona
+- Test validation fails for missing file, missing required fields
+- Test `build_instruction()` output contains persona name, scope rules, decline template
+- Test greeting override works per locale
+- Test greeting fallback when persona has no greetings
+- Verify existing `test_config.py` tests pass with `PERSONA` set
+
+Files: `tests/unit/test_persona.py`, `tests/unit/test_config.py` (may need `PERSONA` env fixture)
+
+### Step 7: Manual testing
+
+- Set `PERSONA=velo_shop` in `.env`
+- Run `just adk` or `just repl`
+- Test 3 in-scope: Öffnungszeiten, E-Bike Beratung, Reparatur-Termin
+- Test 3 out-of-scope: Wetter, Pizza bestellen, Aktienkurs
+- Verify decline is natural, not robotic
+
+## Dependencies & Risks
+
+- **New dependency:** `pyyaml` — standard, no risk
+- **Breaking change:** `PERSONA` env var becomes required. Existing `.env` files need updating. Mitigate: clear error message at startup
+- **Existing tests:** `test_config.py` tests call `build_instruction()` against real files. Once `base.txt` gains `{persona_block}`, these tests need `PERSONA` env set. Use a pytest fixture or conftest to set it.
+- **Deploy:** Cloud Run `just deploy` recipe needs `PERSONA` added to `--set-env-vars`
+
+## Sources & References
+
+- **Origin brainstorm:** [docs/brainstorms/2026-04-16-persona-scoping-brainstorm.md](docs/brainstorms/2026-04-16-persona-scoping-brainstorm.md) — key decisions: YAML per persona, env var selection, no voice override in persona, honest+escalation for missing facts
+- Related issue: #9
+- Closely related: #11 (no hallucinated capabilities — persona scope rules reinforce this)
+- Current prompt: `voice_assistant/prompts/base.txt:1-22`
+- Config assembly: `voice_assistant/config.py:100-182`
+- Agent wiring: `voice_assistant/agent.py:41-53`
+- Existing tests: `tests/unit/test_config.py`

--- a/justfile
+++ b/justfile
@@ -282,7 +282,7 @@ fmt:
 # Clean up Python bytecode, test and build artifacts
 [group('lifecycle')]
 clean *args:
-    uvx pyclean . -d all {{ args }}
+    uvx pyclean . -i .direnv -d all {{ args }}
 
 # ── Operations ────────────────────────────────────────────────────────────────
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,27 @@ description = "Customer support hotline with Twilio + Google ADK (Gemini Live AP
 requires-python = ">=3.13"
 dependencies = [
     "google-adk>=1.28.0",
-    "audioop-lts>=0.2.1",   # mulaw <-> pcm conversion (Python 3.13+ compatible)
+    "audioop-lts>=0.2.1",  # mulaw <-> pcm conversion (Python 3.13+ compatible)
     "pyyaml>=6.0.3",
     "websockets>=15.0.1",
 ]
+
+[dependency-groups]
+dev = [
+    "google-adk[eval]>=1.28.0",
+    "pyright>=1.1.408",
+    "pytest>=9.0.2",
+    "pytest-asyncio>=0.25.0",
+    "pytest-cov>=6.1.1",
+]
+
+[tool.coverage.report]
+exclude_also = ["if __name__ == .__main__.:"]
+skip_covered = true
+show_missing = true
+
+[tool.coverage.run]
+source = ["voice_assistant"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
@@ -20,24 +37,8 @@ filterwarnings = [
 [tool.setuptools.packages.find]
 include = ["voice_assistant*"]
 
-[tool.coverage.run]
-source = ["voice_assistant"]
-
-[tool.coverage.report]
-exclude_also = ["if __name__ == .__main__.:"]
-skip_covered = true
-show_missing = true
+[tool.setuptools.package-data]
+"voice_assistant" = ["personas/*.yaml", "prompts/*.txt"]
 
 [tool.uv]
 package = true
-
-[tool.uv.sources]
-
-[dependency-groups]
-dev = [
-    "google-adk[eval]>=1.28.0",
-    "pyright>=1.1.408",
-    "pytest>=9.0.2",
-    "pytest-asyncio>=0.25.0",
-    "pytest-cov>=6.1.1",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.13"
 dependencies = [
     "google-adk>=1.28.0",
     "audioop-lts>=0.2.1",   # mulaw <-> pcm conversion (Python 3.13+ compatible)
+    "pyyaml>=6.0.3",
     "websockets>=15.0.1",
 ]
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,9 @@
+"""Unit test configuration.
+
+Set PERSONA env var before any voice_assistant imports so that
+config.py loads a valid persona at module level.
+"""
+
+import os
+
+os.environ.setdefault("PERSONA", "velo_shop")

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from voice_assistant.agent import _DualModelGemini, _instruction_provider, root_agent
-from voice_assistant.config import GEMINI_MODEL, GEMINI_LIVE_MODEL
+from voice_assistant.agent import _DualModelGemini, _make_instruction_provider, root_agent
+from voice_assistant.config import GEMINI_MODEL, GEMINI_LIVE_MODEL, PERSONA
 
 
 # ---------------------------------------------------------------------------
@@ -18,7 +18,8 @@ def test_root_agent_exists():
 
 
 def test_root_agent_name():
-    assert root_agent.name == "customer_service"
+    # Agent name derived from active persona
+    assert root_agent.name == "velo_zueri"
 
 
 def test_root_agent_has_no_tools_for_native_audio():
@@ -49,24 +50,27 @@ def test_dual_model_is_gemini_subclass():
 
 
 def test_instruction_provider_uses_language_from_state():
+    provider = _make_instruction_provider(PERSONA)
     ctx = MagicMock()
     ctx.state = {"language": "fr-CH"}
-    instruction = _instruction_provider(ctx)
+    instruction = provider(ctx)
     assert "Swiss French" in instruction
 
 
 def test_instruction_provider_defaults_to_configured_language():
+    provider = _make_instruction_provider(PERSONA)
     ctx = MagicMock()
     ctx.state = {}
-    instruction = _instruction_provider(ctx)
+    instruction = provider(ctx)
     # Should use default language from settings
     assert len(instruction) > 100
 
 
 def test_instruction_provider_italian():
+    provider = _make_instruction_provider(PERSONA)
     ctx = MagicMock()
     ctx.state = {"language": "it-CH"}
-    instruction = _instruction_provider(ctx)
+    instruction = provider(ctx)
     assert "Swiss Italian" in instruction
 
 

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import importlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from voice_assistant.agent import _DualModelGemini, _make_instruction_provider, root_agent
+import pytest
+
+from voice_assistant.agent import (
+    _DualModelGemini,
+    _make_instruction_provider,
+    root_agent,
+)
 from voice_assistant.config import GEMINI_MODEL, GEMINI_LIVE_MODEL, PERSONA
 
 
@@ -102,3 +109,40 @@ async def test_dual_model_connect_swaps_model():
 
     # After exiting, model should be restored
     assert llm_request.model == GEMINI_MODEL
+
+
+# ---------------------------------------------------------------------------
+# Module-level agent wiring
+# ---------------------------------------------------------------------------
+
+
+def test_no_personas_raises():
+    import voice_assistant.agent as agent_mod
+
+    with patch("voice_assistant.config.load_all_personas", return_value={}):
+        with pytest.raises(EnvironmentError, match="No persona YAML files"):
+            importlib.reload(agent_mod)
+
+    # Restore module to working state
+    importlib.reload(agent_mod)
+
+
+def test_multiple_personas_creates_router():
+    import voice_assistant.agent as agent_mod
+
+    second_persona = {
+        "name": "Test Shop",
+        "allowed_topics": ["Topic A"],
+        "out_of_scope_decline": "Sorry.",
+    }
+    two_personas = {
+        "velo_shop": PERSONA,
+        "test_shop": second_persona,
+    }
+    with patch("voice_assistant.config.load_all_personas", return_value=two_personas):
+        importlib.reload(agent_mod)
+        assert agent_mod.root_agent.name == "voice_assistant"
+        assert len(agent_mod.root_agent.sub_agents) == 2
+
+    # Restore module to working state
+    importlib.reload(agent_mod)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
+import voice_assistant
 from voice_assistant.config import (
     FAREWELL_PHRASES,
     LANGUAGE_PROFILES,
@@ -168,3 +171,16 @@ def test_language_profile_has_elevenlabs_voice_id(lang_code):
     profile = LANGUAGE_PROFILES[lang_code]
     assert "elevenlabs_voice_id" in profile
     assert len(profile["elevenlabs_voice_id"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Package data files
+# ---------------------------------------------------------------------------
+
+
+def test_package_data_files_are_present():
+    """Verify non-Python data files are shipped with the package."""
+    pkg = Path(voice_assistant.__file__).parent
+    assert (pkg / "prompts" / "base.txt").is_file()
+    assert (pkg / "prompts" / "escalation.txt").is_file()
+    assert list((pkg / "personas").glob("*.yaml"))

--- a/tests/unit/test_persona.py
+++ b/tests/unit/test_persona.py
@@ -1,0 +1,166 @@
+"""Unit tests for persona loading, validation, and prompt composition."""
+
+from __future__ import annotations
+
+import pytest
+
+from voice_assistant.config import (
+    PERSONA,
+    PERSONA_BLOCK,
+    _load_persona,
+    _render_persona_block,
+    build_instruction,
+    load_all_personas,
+    settings,
+)
+
+
+# ---------------------------------------------------------------------------
+# Persona loading
+# ---------------------------------------------------------------------------
+
+
+def test_load_persona_returns_dict():
+    persona = _load_persona("velo_shop")
+    assert isinstance(persona, dict)
+    assert persona["name"] == "Velo Züri"
+
+
+def test_load_persona_has_required_fields():
+    persona = _load_persona("velo_shop")
+    assert "name" in persona
+    assert "allowed_topics" in persona
+    assert "out_of_scope_decline" in persona
+
+
+def test_load_persona_missing_file_raises():
+    with pytest.raises(EnvironmentError, match="Persona file not found"):
+        _load_persona("nonexistent_persona")
+
+
+def test_load_persona_has_business_facts():
+    persona = _load_persona("velo_shop")
+    assert "business_facts" in persona
+    assert "hours" in persona["business_facts"]
+
+
+# ---------------------------------------------------------------------------
+# Persona block rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_persona_block_contains_name():
+    block = _render_persona_block(PERSONA)
+    assert "Velo Züri" in block
+
+
+def test_render_persona_block_contains_topics():
+    block = _render_persona_block(PERSONA)
+    assert "YOUR EXPERTISE" in block
+    assert "Velo-Reparatur" in block
+
+
+def test_render_persona_block_contains_facts():
+    block = _render_persona_block(PERSONA)
+    assert "BUSINESS INFORMATION" in block
+    assert "Canyon" in block
+
+
+def test_render_persona_block_contains_scope_rules():
+    block = _render_persona_block(PERSONA)
+    assert "SCOPE RULES" in block
+    assert "NEVER pretend" in block
+
+
+def test_render_persona_block_contains_decline():
+    block = _render_persona_block(PERSONA)
+    assert "ausserhalb meines Bereichs" in block
+
+
+def test_render_minimal_persona():
+    minimal = {
+        "name": "Test Shop",
+        "allowed_topics": ["Topic A"],
+        "out_of_scope_decline": "Sorry, can't help with that.",
+    }
+    block = _render_persona_block(minimal)
+    assert "Test Shop" in block
+    assert "Topic A" in block
+    assert "No additional facts available." in block
+
+
+# ---------------------------------------------------------------------------
+# Module-level persona state
+# ---------------------------------------------------------------------------
+
+
+def test_persona_loaded_at_module_level():
+    assert PERSONA["name"] == "Velo Züri"
+    assert len(PERSONA_BLOCK) > 100
+
+
+# ---------------------------------------------------------------------------
+# Prompt composition with persona
+# ---------------------------------------------------------------------------
+
+
+def test_build_instruction_contains_persona_name():
+    instruction = build_instruction("de-CH")
+    assert "Velo Züri" in instruction
+
+
+def test_build_instruction_contains_scope_rules():
+    instruction = build_instruction("de-CH")
+    assert "SCOPE RULES" in instruction
+    assert "NEVER pretend" in instruction
+
+
+def test_build_instruction_contains_decline_template():
+    instruction = build_instruction("de-CH")
+    assert "ausserhalb meines Bereichs" in instruction
+
+
+def test_build_instruction_still_has_escalation():
+    instruction = build_instruction("de-CH")
+    assert "ESCALATION" in instruction
+
+
+# ---------------------------------------------------------------------------
+# Greeting override
+# ---------------------------------------------------------------------------
+
+
+def test_greeting_override_from_persona():
+    profile = settings.language_profile("de-CH")
+    assert "Velo Züri" in profile["greeting"]
+
+
+def test_greeting_override_preserves_other_fields():
+    profile = settings.language_profile("de-CH")
+    assert "voice_name" in profile
+    assert "fallback_reply" in profile
+
+
+def test_greeting_fallback_for_unknown_locale():
+    profile = settings.language_profile("xx-XX")
+    # Falls back to default language profile; persona may or may not have
+    # a greeting for the default locale, but the profile must have a greeting.
+    assert "greeting" in profile
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_load_all_personas():
+    personas = load_all_personas()
+    assert "velo_shop" in personas
+    assert personas["velo_shop"]["name"] == "Velo Züri"
+
+
+def test_default_persona_name_picks_first_available():
+    from voice_assistant.config import _default_persona_name
+
+    name = _default_persona_name()
+    assert name == "velo_shop"

--- a/tests/unit/test_persona.py
+++ b/tests/unit/test_persona.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import pytest
 
+from unittest.mock import patch
+
 from voice_assistant.config import (
     PERSONA,
     PERSONA_BLOCK,
+    _default_persona_name,
     _load_persona,
     _render_persona_block,
     build_instruction,
@@ -159,8 +162,27 @@ def test_load_all_personas():
     assert personas["velo_shop"]["name"] == "Velo Züri"
 
 
-def test_default_persona_name_picks_first_available():
-    from voice_assistant.config import _default_persona_name
-
+def test_default_persona_name_picks_first_available(monkeypatch):
+    monkeypatch.delenv("PERSONA", raising=False)
     name = _default_persona_name()
     assert name == "velo_shop"
+
+
+def test_default_persona_name_returns_empty_when_no_files(tmp_path, monkeypatch):
+    monkeypatch.delenv("PERSONA", raising=False)
+    with patch("voice_assistant.config._PERSONAS_DIR", tmp_path):
+        assert _default_persona_name() == ""
+
+
+def test_load_persona_invalid_yaml(tmp_path):
+    (tmp_path / "bad.yaml").write_text("just a string")
+    with patch("voice_assistant.config._PERSONAS_DIR", tmp_path):
+        with pytest.raises(EnvironmentError, match="YAML mapping"):
+            _load_persona("bad")
+
+
+def test_load_persona_missing_required_fields(tmp_path):
+    (tmp_path / "incomplete.yaml").write_text("name: Test\n")
+    with patch("voice_assistant.config._PERSONAS_DIR", tmp_path):
+        with pytest.raises(EnvironmentError, match="missing required fields"):
+            _load_persona("incomplete")

--- a/uv.lock
+++ b/uv.lock
@@ -3162,6 +3162,7 @@ source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },
     { name = "google-adk" },
+    { name = "pyyaml" },
     { name = "websockets" },
 ]
 
@@ -3178,6 +3179,7 @@ dev = [
 requires-dist = [
     { name = "audioop-lts", specifier = ">=0.2.1" },
     { name = "google-adk", specifier = ">=1.28.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "websockets", specifier = ">=15.0.1" },
 ]
 

--- a/voice_assistant/agent.py
+++ b/voice_assistant/agent.py
@@ -3,6 +3,11 @@ Google ADK agent definition for the voice assistant.
 
 The ``root_agent`` is discovered automatically by the ADK CLI
 (``adk web .``, ``adk run voice_assistant``).
+
+Each persona YAML in ``voice_assistant/personas/`` becomes a separate
+ADK agent.  When multiple personas exist they are registered as
+sub-agents of a lightweight router so the ADK web UI shows them all
+in the agent dropdown.
 """
 
 from __future__ import annotations
@@ -16,7 +21,13 @@ from google.adk.models.base_llm_connection import BaseLlmConnection
 from google.adk.models.google_llm import Gemini
 from google.adk.models.llm_request import LlmRequest
 
-from .config import GEMINI_MODEL, GEMINI_LIVE_MODEL, build_instruction, settings
+from .config import (
+    GEMINI_MODEL,
+    GEMINI_LIVE_MODEL,
+    build_instruction_for_persona,
+    load_all_personas,
+    settings,
+)
 from .tools import ALL_TOOLS
 
 
@@ -44,16 +55,57 @@ class _DualModelGemini(Gemini):
             llm_request.model = original_model
 
 
-def _instruction_provider(ctx: ReadonlyContext) -> str:
-    """Dynamic instruction provider that reads language from session state."""
-    lang = ctx.state.get("language", settings.default_language)
-    return build_instruction(lang)
+def _make_instruction_provider(persona: dict):
+    """Create a per-persona instruction provider for ADK."""
+
+    def _provider(ctx: ReadonlyContext, _persona: dict = persona) -> str:
+        lang = ctx.state.get("language", settings.default_language)
+        return build_instruction_for_persona(_persona, lang)
+
+    return _provider
 
 
-root_agent = Agent(
-    model=_DualModelGemini(model=GEMINI_MODEL),
-    name="customer_service",
-    description="Swiss customer service voice assistant",
-    instruction=_instruction_provider,
-    tools=ALL_TOOLS,
-)
+def _agent_name(persona: dict) -> str:
+    """Derive a valid ADK agent name from a persona."""
+    return persona["name"].lower().replace(" ", "_").replace("ü", "ue")
+
+
+def _build_persona_agent(persona: dict) -> Agent:
+    """Create an ADK Agent for a single persona."""
+    return Agent(
+        model=_DualModelGemini(model=GEMINI_MODEL),
+        name=_agent_name(persona),
+        description=f"{persona['name']} voice assistant",
+        instruction=_make_instruction_provider(persona),
+        tools=ALL_TOOLS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Build agents from all persona YAML files
+# ---------------------------------------------------------------------------
+
+_all_personas = load_all_personas()
+if not _all_personas:
+    raise EnvironmentError(
+        "No persona YAML files found in voice_assistant/personas/. "
+        "Add at least one persona file to start the agent."
+    )
+_persona_agents = [_build_persona_agent(p) for p in _all_personas.values()]
+
+if len(_persona_agents) == 1:
+    # Single persona → use directly as root agent
+    root_agent = _persona_agents[0]
+else:
+    # Multiple personas → router delegates to the right sub-agent
+    root_agent = Agent(
+        model=Gemini(model=GEMINI_MODEL),
+        name="voice_assistant",
+        description="Voice assistant router — delegates to persona-specific agents",
+        instruction=(
+            "You are a router. The user will be connected to one of your "
+            "specialist agents. Transfer the conversation to the most "
+            "appropriate agent immediately."
+        ),
+        sub_agents=list(_persona_agents),  # type: ignore[arg-type]
+    )

--- a/voice_assistant/config.py
+++ b/voice_assistant/config.py
@@ -8,11 +8,15 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import yaml
 from dotenv import load_dotenv
 
 load_dotenv()
 
 _PROMPTS_DIR = Path(__file__).parent / "prompts"
+_PERSONAS_DIR = Path(__file__).parent / "personas"
+
+_PERSONA_REQUIRED_FIELDS = ("name", "allowed_topics", "out_of_scope_decline")
 
 
 # ---------------------------------------------------------------------------
@@ -107,6 +111,106 @@ SYSTEM_INSTRUCTION_TEMPLATE = (_PROMPTS_DIR / "base.txt").read_text()
 _ESCALATION_PROMPT = (_PROMPTS_DIR / "escalation.txt").read_text()
 
 
+# ---------------------------------------------------------------------------
+# Persona loading
+# ---------------------------------------------------------------------------
+
+
+def _load_persona(name: str) -> dict:
+    """Load and validate a persona YAML file by name."""
+    path = _PERSONAS_DIR / f"{name}.yaml"
+    if not path.exists():
+        raise EnvironmentError(
+            f"Persona file not found: {path}\n"
+            f"Set PERSONA to a valid persona name "
+            f"(available: {', '.join(p.stem for p in _PERSONAS_DIR.glob('*.yaml'))})"
+        )
+    data = yaml.safe_load(path.read_text())
+    if not isinstance(data, dict):
+        raise EnvironmentError(
+            f"Persona '{name}' must be a YAML mapping with fields: "
+            f"{', '.join(_PERSONA_REQUIRED_FIELDS)}"
+        )
+    missing = [f for f in _PERSONA_REQUIRED_FIELDS if f not in data]
+    if missing:
+        raise EnvironmentError(
+            f"Persona '{name}' is missing required fields: {', '.join(missing)}"
+        )
+    return data
+
+
+def _render_persona_block(persona: dict) -> str:
+    """Render persona data into a prompt section."""
+    topics = "\n".join(f"- {t}" for t in persona["allowed_topics"])
+
+    facts_lines = []
+    for key, value in persona.get("business_facts", {}).items():
+        label = key.replace("_", " ").title()
+        if isinstance(value, list):
+            facts_lines.append(f"- {label}: {', '.join(value)}")
+        else:
+            facts_lines.append(f"- {label}: {value}")
+    facts = "\n".join(facts_lines) if facts_lines else "No additional facts available."
+
+    decline = persona["out_of_scope_decline"].strip()
+
+    return (
+        f"You are a friendly and professional representative for "
+        f"{persona['name']}.\n"
+        f"{persona.get('tagline', '')}\n"
+        f"Located at: {persona.get('location', 'N/A')}\n"
+        f"\n"
+        f"YOUR EXPERTISE:\n{topics}\n"
+        f"\n"
+        f"BUSINESS INFORMATION:\n{facts}\n"
+        f"\n"
+        f"SCOPE RULES:\n"
+        f"- If the customer asks about something NOT listed under YOUR EXPERTISE, "
+        f"respond approximately like this:\n"
+        f'  "{decline}"\n'
+        f"- If the customer asks about something in your expertise but you lack "
+        f"specific data (e.g. current stock, exact pricing for a model), say so "
+        f"honestly and offer to take a note or connect them with a colleague.\n"
+        f"- NEVER pretend to look things up or claim capabilities you do not have."
+    )
+
+
+def load_all_personas() -> dict[str, dict]:
+    """Load and validate all persona YAML files from the personas directory."""
+    personas = {}
+    for path in sorted(_PERSONAS_DIR.glob("*.yaml")):
+        personas[path.stem] = _load_persona(path.stem)
+    return personas
+
+
+def build_instruction_for_persona(persona: dict, lang_code: str | None = None) -> str:
+    """Build the full system instruction for a specific persona and language."""
+    lang = lang_code or settings.default_language
+    profile = LANGUAGE_PROFILES.get(lang, LANGUAGE_PROFILES[settings.default_language])
+    block = _render_persona_block(persona)
+    base = SYSTEM_INSTRUCTION_TEMPLATE.format(
+        persona_block=block,
+        language_display=profile["display"],
+    )
+    return f"{base}\n\n{_ESCALATION_PROMPT}"
+
+
+def _default_persona_name() -> str:
+    """Return PERSONA env var, or the first available persona file."""
+    name = os.getenv("PERSONA", "")
+    if name:
+        return name
+    available = sorted(p.stem for p in _PERSONAS_DIR.glob("*.yaml"))
+    if available:
+        return available[0]
+    return ""
+
+
+_PERSONA_NAME = _default_persona_name()
+PERSONA: dict = _load_persona(_PERSONA_NAME) if _PERSONA_NAME else {}
+PERSONA_BLOCK: str = _render_persona_block(PERSONA) if PERSONA else ""
+
+
 @dataclass
 class Settings:
     # Twilio – required at runtime, read lazily so imports work without .env
@@ -153,6 +257,9 @@ class Settings:
         default_factory=lambda: os.getenv("ELEVENLABS_MODEL_ID", "eleven_turbo_v2_5")
     )
 
+    # Persona
+    persona: str = field(default_factory=lambda: os.getenv("PERSONA", ""))
+
     _VALID_VOICE_BACKENDS = {"gemini", "elevenlabs"}
 
     def validate(self, *, require_twilio: bool = True) -> None:
@@ -187,11 +294,18 @@ class Settings:
 
     def language_profile(self, lang_code: str | None = None) -> dict:
         code = lang_code or self.default_language
-        return LANGUAGE_PROFILES.get(code, LANGUAGE_PROFILES[self.default_language])
+        profile = LANGUAGE_PROFILES.get(code, LANGUAGE_PROFILES[self.default_language])
+        persona_greeting = PERSONA.get("greetings", {}).get(code)
+        if persona_greeting:
+            profile = {**profile, "greeting": persona_greeting.strip()}
+        return profile
 
     def system_instruction(self, lang_code: str | None = None) -> str:
         profile = self.language_profile(lang_code)
-        base = SYSTEM_INSTRUCTION_TEMPLATE.format(language_display=profile["display"])
+        base = SYSTEM_INSTRUCTION_TEMPLATE.format(
+            persona_block=PERSONA_BLOCK,
+            language_display=profile["display"],
+        )
         return f"{base}\n\n{_ESCALATION_PROMPT}"
 
 

--- a/voice_assistant/personas/velo_shop.yaml
+++ b/voice_assistant/personas/velo_shop.yaml
@@ -1,0 +1,43 @@
+name: "Velo Züri"
+tagline: "Ihr Velofachgeschäft in Zürich"
+location: "Langstrasse 42, 8004 Zürich"
+
+allowed_topics:
+  - Öffnungszeiten und Standort
+  - Velo-Reparatur und Service
+  - Velo-Verkauf und Beratung
+  - E-Bike Beratung
+  - Zubehör und Ersatzteile
+  - Termin vereinbaren
+
+business_facts:
+  hours: "Mo-Fr 09:00-18:30, Sa 09:00-16:00, So geschlossen"
+  services:
+    - Velo-Reparatur und Wartung
+    - E-Bike Beratung und Verkauf
+    - Kinder- und Stadtvelos
+    - Zubehör (Helme, Schlösser, Lichter)
+  brands:
+    - Canyon
+    - Trek
+    - Specialized
+    - Flyer (E-Bikes)
+  price_range: "Stadtvelos ab CHF 500, E-Bikes ab CHF 2'500"
+
+out_of_scope_decline: >
+  Das liegt leider ausserhalb meines Bereichs — ich bin spezialisiert
+  auf Velo-Themen. Kann ich Ihnen bei etwas rund ums Velo weiterhelfen?
+
+greetings:
+  de-CH: >
+    Grüezi! Sie sind mit Velo Züri verbunden.
+    Wie kann ich Ihnen helfen?
+  de-DE: >
+    Hallo! Sie sind mit Velo Züri verbunden.
+    Wie kann ich Ihnen helfen?
+  fr-CH: >
+    Bonjour! Vous êtes en contact avec Velo Züri.
+    Comment puis-je vous aider?
+  it-CH: >
+    Buongiorno! Benvenuto da Velo Züri.
+    Come posso aiutarla?

--- a/voice_assistant/prompts/base.txt
+++ b/voice_assistant/prompts/base.txt
@@ -1,4 +1,4 @@
-You are a friendly and professional customer service representative for a Swiss company.
+{persona_block}
 You are speaking on the phone with a customer.
 
 IMPORTANT RULES:
@@ -7,7 +7,6 @@ IMPORTANT RULES:
 - If you cannot answer a question, offer to connect the customer to a specialist or take a message.
 - Never make up information you are not sure about.
 - Today's date and time are available in the conversation context if needed.
-- Do not pretend to look things up or claim capabilities you do not have. If a customer asks for something you cannot do, say so honestly and offer what you can help with instead.
 
 LANGUAGE SWITCHING:
 - If the customer asks whether you speak another language (e.g. French, Italian, German, English), switch to that language immediately and continue the conversation entirely in the new language.


### PR DESCRIPTION
## Summary
- YAML-based persona system: drop a file in `personas/` → agent auto-scoped to that business
- First persona: fictional Swiss bike shop "Velo Züri" with topics, facts, decline template
- Each persona YAML auto-creates its own ADK agent (multi-agent ready)
- Default persona auto-selected (no `PERSONA` env var required)
- Out-of-scope questions declined gracefully, in-scope unknowns handled honestly via escalation
- Greeting override per locale from persona config

## Test plan
- [x] 120 unit tests passing (including 20 new persona tests)
- [x] Lint + type check clean
- [ ] Manual test: `just adk` → 3 in-scope questions answered, 3 out-of-scope declined
- [ ] Manual test: add second persona YAML → appears as separate ADK agent

## Key files
| File | Change |
|------|--------|
| `voice_assistant/personas/velo_shop.yaml` | New — Velo Züri persona definition |
| `voice_assistant/config.py` | Persona loader, renderer, greeting override, `load_all_personas()` |
| `voice_assistant/prompts/base.txt` | Refactored — `{persona_block}` slot replaces hard-coded identity |
| `voice_assistant/agent.py` | Dynamic agent creation from all persona YAMLs |
| `tests/unit/test_persona.py` | New — 20 tests for persona loading, rendering, prompt composition |

🤖 Generated with [Claude Code](https://claude.com/claude-code)